### PR TITLE
fix(store): Store undecided block data first

### DIFF
--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -648,7 +648,7 @@ pub async fn run(
                     "💡 Sync block validated at height {} with hash: {}",
                     height, new_block_hash
                 );
-                let proposed_value: ProposedValue<MalakethContext> = ProposedValue {
+                let proposed_value: ProposedValue<EmeraldContext> = ProposedValue {
                     height,
                     round,
                     valid_round: Round::Nil,

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -608,7 +608,7 @@ impl State {
         // We create a new value.
         let value = Value::new(data.clone());
 
-        let proposal: ProposedValue<MalakethContext> = ProposedValue {
+        let proposal: ProposedValue<EmeraldContext> = ProposedValue {
             height,
             round,
             valid_round: Round::Nil,


### PR DESCRIPTION
When a node syncs, it stores the complete proposal and the block data. These operations are not atomic. If a crash happens between them, on restart, consensus is notified that there is a proposal ready. But we do not have the block data stored. 

Consensus gets into `Decided` and crashes with the error : `app: certificate should have associated block data`. 

To reproduce: 

1. Start a network of 4 nodes. 
2. Kill one of the nodes (`scripts/kill_node.sh 3`).
3. Insert a `panic` between `store_undecided_proposal` and `store_undecided_block_data` 
4. Restart the node (edit scripts/restart_node.sh to run cargo build before cargo run) : restart_node.sh 3
5. Node will crash
6. Remove the panic, reorder the operations. 
7. Restart the node again. 
8. Sync should work. 
