### PR TITLE
fix(make): Paramatrize reth volume cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,14 @@ build:
 stop:
 	docker compose down
 
-clean: clean-prometheus
+clean-volumes:
+	docker volume ls --format '{{.Name}}' | grep -E 'reth' | xargs -r docker volume rm || true
+
+clean: clean-prometheus clean-volumes
 	rm -rf ./.testnet
 	rm -rf ./assets/genesis.json
 	rm -rf ./nodes
 	rm -rf ./monitoring/data-grafana
-	docker volume rm --force emerald_reth0
-	docker volume rm --force emerald_reth1
-	docker volume rm --force emerald_reth2
-	docker volume rm --force emerald_reth3
 
 clean-prometheus: stop
 	rm -rf ./monitoring/data-prometheus


### PR DESCRIPTION
There docker volumes were named based on the local folder but the cleanup hard codes the name as `emerald-reth0` .The PR removes the volume based on a pattern rather than a hardcoded value. 

