### PR TITLE
fix(ci): Workflow matches main

### DIFF
--- a/.github/workflows/emerald.yml
+++ b/.github/workflows/emerald.yml
@@ -46,7 +46,6 @@ jobs:
               - '**/Cargo.lock'
               - '**/.sh'
               - '*/workflows/emerald.yml'
-              - '*/workflows/test.yml'
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
               - '**/Cargo.toml'
               - '**/Cargo.lock'
               - '**/.sh'
+              - '*/workflows/test.yml'
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:


### PR DESCRIPTION
This PR:
- Skips running `emerald.yml` and `test.yml` when not chasing rust files, Makefile and emerald.yml itself. 