### PR TITLE
test(mbt): Model node crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "quint-connect"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2518a72e1f89b9d2248d695554f22733fe8600ff8899b33c629502f6b0b516a"
+checksum = "6a66d8666ae428df917037dc064921a48ac74ff5758033aa388c1cd3e24af551"
 dependencies = [
  "anyhow",
  "colored",
@@ -5736,9 +5736,9 @@ dependencies = [
 
 [[package]]
 name = "quint-connect-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7be4d8093c3153727edc24112a4693e60aa78650f277f79dd415118b4ee27b"
+checksum = "dfca0f8a49678da6e1a671b5aab8e284a8b548096e6921c0640986a7b451eaff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,8 @@ mbt-start-reth: build
 
 mbt-test:
 	@echo "Running MBT tests..."
-	./tests/mbt/run-tests.sh
+	./tests/mbt/run-tests.sh sigle_height_consensus
+	./tests/mbt/run-tests.sh node_crash_after_consensus
 
 mbt-clean:
 	rm -rf ./tests/mbt/.reth-data

--- a/specs/emerald_app.qnt
+++ b/specs/emerald_app.qnt
@@ -79,8 +79,9 @@ module emerald_app {
     | DecidedAction({ node: Node, proposal: Proposal })
     | ProcessSyncedValueAction({ node: Node, proposal: Proposal })
     | GetDecidedValueAction({ node: Node, proposal: Proposal })
+    | NodeCrash({ node: Node })
 
-  // Local state for each app node (based on state.rs:76-109)
+  // Local state for each app node
   type StateFields = {
     phase: AppPhase,
     // Current consensus state
@@ -383,9 +384,27 @@ module emerald_app {
     }
   }
 
-  // TODO: Model failures: restart (and crash?)
   // TODO: Implement GetHistoryMinHeight (requires modeling certificate pruning).
   // TODO: Implement RestreamProposal.
+
+  // ===== NodeCrash: A node crashes and comes back without any state =====
+
+  pure def node_crash(ctx: LocalContext): Set[Transition] = {
+    val s = ctx.state
+
+    Set({
+      post_state: initialize(s.process_id),
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          NodeCrash({
+            node: s.process_id,
+          })
+        ))
+      )
+    })
+  }
+
+  // TODO: Model node restart
 
   // =============================================================================
   // MAIN LISTENER
@@ -409,6 +428,9 @@ module emerald_app {
       // Synchronization protocol
       choreo::cue(ctx, listen_process_synced_value, handle_process_synced_value),
       choreo::cue(ctx, listen_get_decided_value, handle_get_decided_value),
+
+      // Crash and recovery
+      node_crash(ctx)
     ).flatten()
   }
 
@@ -517,4 +539,7 @@ module emerald_app {
 
   action perform(cue_ctx, upon_fn) =
     choreo::perform(cue_ctx, upon_fn, apply_custom_effect)
+
+  action step_with(node: Node, listener: LocalContext => Set[Transition]): bool =
+    choreo::step_with(node, listener, apply_custom_effect)
 }

--- a/specs/emerald_tests.qnt
+++ b/specs/emerald_tests.qnt
@@ -1,4 +1,4 @@
-module emerald_test {
+module emerald_tests {
   import basicSpells.* from "spells/basicSpells"
   import rareSpells.* from "spells/rareSpells"
   import emerald_app.* from "emerald_app"
@@ -84,4 +84,61 @@ module emerald_test {
       // get_value (2nd)
       .then("node1".with_cue(listen_get_value, ()).perform(handle_get_value))
       .expect(s.system.get("node1").proposals == Set(firstProposal)) // same proposal
+
+  run emeraldNodeCrashAfterConsensusTest =
+    genesisStart
+      // first consensus
+      .then("node1".with_cue(listen_get_value, ()).perform(handle_get_value))
+      .then("node2".with_cue(listen_received_proposal, firstProposal).perform(handle_received_proposal))
+      .then("node3".with_cue(listen_received_proposal, firstProposal).perform(handle_received_proposal))
+      .then("node1".with_cue(listen_decided, firstProposal).perform(handle_decided))
+      .then("node2".with_cue(listen_decided, firstProposal).perform(handle_decided))
+      .then("node3".with_cue(listen_decided, firstProposal).perform(handle_decided))
+      // node crashes
+      .then("node1".step_with(node_crash))
+      .expect(
+        val st = s.system.get("node1")
+        and {
+          st.phase == Uninitialized,
+          st.current_height == 0,
+          st.current_round == 0,
+          st.proposals.size() == 0,
+          st.latest_block_height == 0,
+          st.latest_block_payload == None
+        }
+      )
+      // node restarts but loses its data
+      .then("node1".with_cue(listen_consensus_ready, ()).perform(handle_consensus_ready))
+      .expect(
+        val st = s.system.get("node1")
+        and {
+          st.phase == Ready,
+          st.current_height == 1,
+          st.current_round == 0,
+          st.proposals == Set()
+        }
+      )
+      // start next height
+      .then("node1".with_cue(listen_started_round, ()).perform(handle_started_round))
+      .then("node2".with_cue(listen_started_round, ()).perform(handle_started_round))
+      .then("node3".with_cue(listen_started_round, ()).perform(handle_started_round))
+      .expect(
+        and {
+          NODES.toSet().forall(node =>
+            s.system.get(node).phase == Working
+          ),
+          s.system.get("node1").current_height == 1, // <- node1 came back at hight 1
+          s.system.get("node2").current_height == 2,
+          s.system.get("node3").current_height == 2
+        }
+      )
+      // get_value
+      .then("node1".with_cue(listen_get_value, ()).perform(handle_get_value))
+      .expect(
+        s.system.get("node1").proposals == Set({
+          ...firstProposal,
+          payload: 1
+        })
+      )
+      // TODO: Model recovery via value sync
 }

--- a/tests/mbt/Cargo.toml
+++ b/tests/mbt/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 dead_code = "allow"
 
 [dependencies]
-quint-connect = { version = "0.1.0" }
+quint-connect = { version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
 itf = "0.4"
 anyhow = "1.0"

--- a/tests/mbt/src/driver.rs
+++ b/tests/mbt/src/driver.rs
@@ -13,7 +13,7 @@ use emerald::node::StateComponents;
 use malachitebft_app_channel::app::streaming::StreamMessage;
 use malachitebft_app_channel::AppMsg;
 use malachitebft_eth_types::{
-    Address, BlockHash, EmeraldContext, ProposalPart, ValueId as EmeraldValueId,
+    Address, BlockHash, EmeraldContext, ProposalPart, Value, ValueId as EmeraldValueId,
 };
 use quint_connect::{switch, Driver, Result, Step};
 use tempfile::TempDir;
@@ -24,6 +24,7 @@ pub struct EmeraldDriver {
     pub nodes: BTreeMap<Node, StateComponents>,
     pub addresses: BiMap<Node, Address>,
     pub proposals: BiMap<Proposal, EmeraldValueId>,
+    pub values: BTreeMap<ValueId, Value>,
     pub streams: BTreeMap<ValueId, Vec<StreamMessage<ProposalPart>>>,
     pub blocks: BiMap<Payload, BlockHash>,
     pub runtime: tokio::runtime::Runtime,
@@ -36,6 +37,7 @@ impl Default for EmeraldDriver {
             nodes: BTreeMap::new(),
             addresses: BiMap::new(),
             proposals: BiMap::new(),
+            values: BTreeMap::new(),
             streams: BTreeMap::new(),
             blocks: BiMap::new(),
             runtime: tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"),
@@ -73,6 +75,9 @@ impl Driver for EmeraldDriver {
             },
             DecidedAction(node, proposal) => {
                 self.handle_decided(node, proposal)
+            },
+            NodeCrash(node) => {
+                self.node_crash(node)
             }
         })
     }

--- a/tests/mbt/src/driver/handle_get_value.rs
+++ b/tests/mbt/src/driver/handle_get_value.rs
@@ -28,8 +28,10 @@ impl EmeraldDriver {
             process_app_message(app, msg).await;
 
             let proposal = reply_rx.await.expect("Failed to handle GetValue");
-            let value_id = proposal.value.id();
+            self.values
+                .insert(expected_proposal.id(), proposal.value.clone());
 
+            let value_id = proposal.value.id();
             let bytes = app
                 .state
                 .get_block_data(proposal.height, proposal.round, value_id)

--- a/tests/mbt/src/tests.rs
+++ b/tests/mbt/src/tests.rs
@@ -9,3 +9,16 @@ use crate::driver::EmeraldDriver;
 fn sigle_height_consensus() -> impl Driver {
     EmeraldDriver::default()
 }
+
+// FIXME: this is another instance of
+// https://github.com/informalsystems/emerald/issues/100. However, there's an
+// workaround where operators can be instructued to kill and wipe out the data
+// for reth, in which case the fix for #100 still applies.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldNodeCrashAfterConsensusTest"
+)]
+#[should_panic = "Payload ID should be Some!"]
+fn node_crash_after_consensus() -> impl Driver {
+    EmeraldDriver::default()
+}


### PR DESCRIPTION
This patch introduces a basic model of node crash: an emerald node crashes -- not reth -- and comes back without its previous state. Note that the test is failing as it's hitting the same condition as #100.