### PR TITLE
fix(ci): The workflow file was not properly filtering rust files

### DIFF
--- a/.github/workflows/emerald.yml
+++ b/.github/workflows/emerald.yml
@@ -40,11 +40,11 @@ jobs:
         with:
           filters: |
             code:
-              - '**/.rs'
+              - '**/*.rs'
               - 'Makefile'
               - '**/Cargo.toml'
               - '**/Cargo.lock'
-              - '**/.sh'
+              - '**/*.sh'
               - '*/workflows/emerald.yml'
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
         with:
           filters: |
             code:
-              - '**/.rs'
+              - '**/*.rs'
               - 'Makefile'
               - '**/Cargo.toml'
               - '**/Cargo.lock'
-              - '**/.sh'
+              - '**/*.sh'
               - '*/workflows/test.yml'
       - name: Install Protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION
The CI was not running because the filters were not properly written in https://github.com/informalsystems/emerald/pull/131 . 

