### PR TITLE
fix(app): Ensure streams are pruned after done

### DIFF
--- a/.changelog/unreleased/fixes/178-fix-streams-map-purge.md
+++ b/.changelog/unreleased/fixes/178-fix-streams-map-purge.md
@@ -1,0 +1,2 @@
+- Ensure streams are pruned after done
+  ([\#178](https://github.com/informalsystems/emerald/pull/178))


### PR DESCRIPTION
Previous code called `StreamState::is_done` inside `StreamState::insert` to check if the stream was complete. If so, it would transfer ownership of its inner parts to the returned `ProposalParts`, making subsequent calls to `is_done` return `false`.

The `StreamState::is_done` was also called after `StreamState::insert` by `PartStreamsMap::insert` to check if the stream was complete and remove it from the pending streams map. Since the second call to `is_done` after the stream is complete always returns `false`, the streams map was never pruned.

This patch modifies the ownership requirements of `StreamState::insert` so it takes ownership over the current stream state. If the stream is incomplete, it returns the ownership back. On completed streams, however, it consumes its inner components and return a `ProposedParts`.

This approach prevents future use of the stream state after its inner components have been transferred to the returned `ProposedParts`.