### PR TITLE
test(mbt): Introduce Quint specs for Emerald

### DIFF
--- a/specs/choreo.qnt
+++ b/specs/choreo.qnt
@@ -1,0 +1,297 @@
+// -*- mode: Bluespec; -*-
+
+/**
+ * Choreo: Choreograph distributed protocols in Quint
+ *
+ * Read the documentation: TODO LINK
+ *
+ * Gabriela Moreira, Josef Widder and Yassine Boukhari,
+ * Informal Systems, 2025
+ */
+
+module choreo {
+  import basicSpells.* from "spells/basicSpells"
+
+  // TODO: try moving process id to local context
+  type LocalState[process_id, ext] = {
+    process_id: process_id
+    | ext
+  }
+
+  type Transition[p, s, m, e, ce] = {
+    post_state: LocalState[p, s],
+    effects: Set[Effect[p, m, e, ce]],
+  }
+
+  type GlobalContext[p, s, m, e, ext] = {
+    system: p -> LocalState[p, s],
+    messages: p -> Set[m],
+    events: p -> Set[e],
+    extensions: ext
+  }
+
+  type LocalContext[p, s, m, e, ext] = {
+    state: LocalState[p, s],
+    messages: Set[m],
+    events: Set[e],
+    extensions: ext
+  }
+
+  // This is the message routing to the # handler
+  type Listener[p, s, m, e, ce, ext] =
+    (LocalContext[p, s, m, e, ext]) => Set[Transition[p, s, m, e, ce]]
+
+  type DeterministicListener[p, s, m, e, ce, ext] =
+    (LocalContext[p, s, m, e, ext]) => Transition[p, s, m, e, ce]
+
+  // Only needed for micro_step
+  type Input[m, e] = Message(m) | Event(e)
+
+  // Only needed for micro_step
+  type MicroListener[p, s, m, e, ce, ext] =
+    (LocalContext[p, s, m, e, ext], Input[m, e]) => Set[Transition[p, s, m, e, ce]]
+
+  type EffectProcessor[p, s, m, e, ce, ext] =
+    (GlobalContext[p, s, m, e, ext], ce) => GlobalContext[p, s, m, e, ext]
+
+
+  type Effect[p, m, e, ce] =
+    | Broadcast(m)
+    | Send({ to: p, message: m })
+    | TriggerEvent(e)
+    | CustomEffect(ce)
+
+  /// A displayer is a function that takes a global context and returns a displayable representation of it.
+  /// This is used to visualize the state of the system for debugging or monitoring purposes.
+  /// After type instantiation, it should have the following signature:
+  /// ```
+  /// (Environment) => Display
+  /// ```
+  /// The display type can be anything.
+  type Displayer[p, s, m, e, ext, d] = (GlobalContext[p, s, m, e, ext]) => d
+
+  pure def apply_effect(
+    env: GlobalContext[p, s, m, e, ext],
+    v: p,
+    tr: Transition[p, s, m, e, ce],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, ext]
+  ): GlobalContext[p, s, m, e, ext] = {
+    val env1 = { ...env, system: env.system.setBy(v, s => tr.post_state) }
+
+    tr.effects.fold(env1, (e, effect) => {
+      match effect {
+        | Broadcast(m) => {
+          { ...e, messages: e.messages.transformValues(b => b.setAdd(m)) }
+        }
+        | Send(r) => {
+          { ...e, messages: e.messages.setBy(r.to, b => b.setAdd(r.message)) }
+        }
+        | TriggerEvent(ev) => {
+          { ...e, events: e.events.setBy(v, b => b.setAdd(ev)) }
+        }
+        | CustomEffect(ex) => {
+          apply_custom_effect(e, ex)
+        }
+      }
+    })
+  }
+
+  const processes: Set[p]
+  var s: GlobalContext[p, s, m, e, ext]
+  var display: d
+
+  pure def initialize(x: a, f: Option[(a) => Set[b]]): Set[b] = {
+    match f {
+      | Some(fun) => fun(x)
+      | None => Set()
+    }
+  }
+
+  pure def convert_context(
+    env: GlobalContext[p, s, m, e, ext],
+    v: p
+  ): LocalContext[p, s, m, e, ext] = {
+    {
+      state: env.system.get(v),
+      messages: env.messages.get(v),
+      events: env.events.get(v),
+      extensions: env.extensions
+    }
+  }
+
+  action process_transitions(
+    v: p,
+    transitions: Set[Transition[p, s, m, e, ce]],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions],
+  ): bool =
+    // FIXME: Quint was supposed to detect determinism alone
+    if (transitions.size() == 1) {
+      val transition = transitions.getOnlyElement()
+      val post_env = apply_effect(s, v, transition, apply_custom_effect)
+      s' = post_env
+    } else {
+      nondet transition = oneOf(transitions)
+      val post_env = apply_effect(s, v, transition, apply_custom_effect)
+      s' = post_env
+    }
+
+  action process_transitions_with_displayer(
+    v: p,
+    transitions: Set[Transition[p, s, m, e, ce]],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions],
+    displayer: Displayer[p, s, m, e, extensions, d],
+  ): bool =
+    // FIXME: Quint was supposed to detect determinism alone
+    if (transitions.size() == 1) {
+      val transition = transitions.getOnlyElement()
+      val post_env = apply_effect(s, v, transition, apply_custom_effect)
+      all {
+        s' = post_env,
+        display' = displayer(post_env),
+      }
+    } else {
+      nondet transition = oneOf(transitions)
+      val post_env = apply_effect(s, v, transition, apply_custom_effect)
+      all {
+        s' = post_env,
+        display' = displayer(post_env),
+      }
+    }
+
+  action init(ctx: GlobalContext[p, s, m , e, ext]): bool = {
+    s' = ctx
+  }
+
+  action init_with_displayer(
+    ctx: GlobalContext[p, s, m , e, ext],
+    displayer: Displayer[p, s, m, e, extensions, d],
+  ): bool = all {
+    s' = ctx,
+    display' = displayer(ctx)
+  }
+
+  action step(
+    listener: Listener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions]
+  ): bool = {
+    nondet v = oneOf(processes)
+    val input = convert_context(s, v)
+    val transitions = listener(input).filter(t => t.effects.size() > 0 or t.post_state != input.state)
+    process_transitions(v, transitions, apply_custom_effect)
+  }
+
+  action step_with_displayer(
+    listener: Listener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions],
+    displayer: Displayer[p, s, m, e, extensions, d]
+  ): bool = {
+    nondet v = oneOf(processes)
+    val input = convert_context(s, v)
+    val transitions = listener(input).filter(t => t.effects.size() > 0 or t.post_state != input.state)
+    process_transitions_with_displayer(v, transitions, apply_custom_effect, displayer)
+  }
+
+  action micro_step(
+    listener: MicroListener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions]
+  ): bool = {
+    nondet process = processes.oneOf()
+    val ctx = convert_context(s, process)
+    any {
+      nondet msg = s.messages.get(process).oneOf()
+      val transitions = listener(ctx, Message(msg))
+      process_transitions(process, transitions, apply_custom_effect),
+
+      nondet event = s.events.get(process).oneOf()
+      val transitions = listener(ctx, Event(event))
+      process_transitions(process, transitions, apply_custom_effect),
+    }
+  }
+
+  action step_with(
+    v: p,
+    listener: Listener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions]
+  ): bool = {
+    val input = convert_context(s, v)
+    val transitions = listener(input).filter(t => t.effects.size() > 0 or t.post_state != input.state)
+    process_transitions(v, transitions, apply_custom_effect)
+  }
+
+  action step_deterministic(
+    v: p,
+    listener: DeterministicListener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions]
+  ): bool = {
+    val input = convert_context(s, v)
+    val transitions = Set(listener(input)).filter(t => t.effects.size() > 0 or t.post_state != input.state)
+    process_transitions(v, transitions, apply_custom_effect)
+  }
+
+  action step_with_filter(
+    v: p,
+    listener: Listener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions],
+    f: (Transition[p, s, m, e, ce]) => bool
+  ): bool = {
+    val input = convert_context(s, v)
+    val transitions = listener(input).filter(t => t.effects.size() > 0 or t.post_state != input.state).filter(f)
+    process_transitions(v, transitions, apply_custom_effect)
+  }
+
+  action step_with_messages(
+    v: p,
+    listener: Listener[p, s, m, e, ce, extensions],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, extensions],
+    f: Set[m] => Set[m]
+  ): bool = {
+    val input = convert_context(s, v)
+    val input1 = { ...input, messages: f(input.messages) }
+    val transitions = listener(input1).filter(t => t.effects.size() > 0 or t.post_state != input.state)
+    process_transitions(v, transitions, apply_custom_effect)
+  }
+
+  action lose_messages(v: p, f: Set[m] => Set[m]): bool = {
+    val msgs = s.messages.get(v)
+    val new_msgs = msgs.exclude(f(msgs))
+    all {
+      s' = { ...s, messages: s.messages.set(v, new_msgs) }
+    }
+  }
+
+  pure def cue(
+    ctx: LocalContext[p, s, m, e, ext],
+    listen_fn: (LocalContext[p, s, m, e, ext]) => Set[r],
+    upon_fn: (LocalContext[p, s, m, e, ext], r) => Transition[p, s, m, e, ce]
+  ): Set[Transition[p, s, m, e, ce]] = {
+    val params = listen_fn(ctx)
+    params.map(param => upon_fn(ctx, param))
+  }
+
+  type CueResult[p, s, m, e, ext, r] = CueOk({ ctx: LocalContext[p, s, m, e, ext], params: r }) | NoCue
+
+  def with_cue(
+    process: p,
+    listen_fn: (LocalContext[p, s, m, e, ext]) => Set[r],
+    params: r
+  ): CueResult[p, s, m, e, ext, r] = {
+    val ctx = convert_context(s, process)
+    val valid_params = listen_fn(ctx)
+    val is_valid = valid_params.contains(params)
+    if (is_valid)
+      CueOk({ ctx: ctx, params: params })
+    else
+      NoCue
+  }
+
+  action perform(
+    cue_result: CueResult[p, s, m, e, ext, r],
+    upon_fn: (LocalContext[p, s, m, e, ext], r) => Transition[p, s, m, e, ce],
+    apply_custom_effect: EffectProcessor[p, s, m, e, ce, ext],
+  ): bool = {
+    match cue_result {
+      | CueOk(cue) => process_transitions(cue.ctx.state.process_id, Set(upon_fn(cue.ctx, cue.params)), apply_custom_effect)
+      | NoCue => all { false, s' = s }
+    }
+  }
+}

--- a/specs/emerald.qnt
+++ b/specs/emerald.qnt
@@ -1,0 +1,713 @@
+// -*- mode: Bluespec; -*-
+
+// =============================================================================
+// Emerald Specification
+// =============================================================================
+//
+// This specification models the Emerald application layer, which sits on top of
+// the Malachite consensus engine and manages the lifecycle of blockchain blocks
+// across multiple distributed nodes.
+//
+// We model Malachite consensus inputs and how Emerald reacts to them. The
+// network, storage, and blockchain systems are considered implementation
+// details and are not modeled here.
+//
+// For model-based testing (MBT), actions and relevant data are tracked as part
+// of global state so they can be made available to Quint Connect for testing.
+
+module emerald {
+  import basicSpells.* from "spells/basicSpells"
+  import rareSpells.* from "spells/rareSpells"
+  import emerald_types.* from "emerald_types"
+  import choreo(processes = NODES.toSet()) as choreo from "choreo"
+
+  // =============================================================================
+  // PROTOCOL CONFIGURATION
+  // =============================================================================
+
+  // The Emerald nodes to test. E.g.: List("node1", "node2", "node3")
+  const NODES: List[Node]
+
+  // =============================================================================
+  // CHOREO BOILERPLATE
+  // =============================================================================
+
+  type LocalState = choreo::LocalState[Node, StateFields]
+  type LocalContext = choreo::LocalContext[Node, StateFields, Message, Event, Extensions]
+  type Transition = choreo::Transition[Node, StateFields, Message, Event, CustomEffects]
+  type GlobalContext = choreo::GlobalContext[Node, StateFields, Message, Event, Extensions]
+
+  // =============================================================================
+  // HELPER FUNCTIONS
+  // =============================================================================
+
+  // Return the proposer for the given height and round
+  pure def proposer_for(height: Height, round: Round): Node =
+    NODES[(height - 1 + round) % NODES.length()]
+
+  // Returns the next block payload.
+  //
+  // For simplicity, we generate payloads as sequential numbers based on how
+  // many proposals there are, thus ensuring a unique payload per proposal
+  // recorded.
+  pure def next_payload(ctx: LocalContext): Payload =
+    ctx.extensions.all_proposals.size()
+
+  // Get a proposal from the local state for the given height and round, if any.
+  pure def get_local_proposal(s: LocalState, height: Height, round: Round): Option[Proposal] =
+    s.proposals.find(p => p.height == height and p.round == round)
+
+  // Get a decided proposal on the global scope for the given height, if any.
+  pure def get_global_decision(ctx: LocalContext, height: Height): Option[Proposal] =
+    ctx.extensions.decided_proposals.find(p => p.height == height)
+
+  // =============================================================================
+  // TRANSITION FUNCTIONS
+  // =============================================================================
+
+  // ===== ConsensusReady: Initialize the system =====
+  // 
+  // Assumption: When starting the process, Malachite will call Emerald with the
+  // ConsensusReady message once it's done initializing. In response, Emerald
+  // will start at the last decided height + 1.
+
+  pure def listen_consensus_ready(ctx: LocalContext): Set[()] =
+    if (ctx.state.phase == Uninitialized) Set(()) else Set()
+
+  pure def handle_consensus_ready(ctx: LocalContext, _params: ()): Transition = {
+    val s = ctx.state
+    val ext = ctx.extensions
+
+    val last_decided_height = ext.last_decided_height.get(s.process_id)
+
+    val s0 =
+      match get_global_decision(ctx, last_decided_height) {
+        // Genesis start: Emerald do not have any previously known decided
+        // value. Consensus height begins in 0.
+        | None => {
+          ...s,
+          consensus_height: 1,
+          last_decided_height: 0,
+          last_decided_payload: None
+        }
+        // Non-genesis start: Emerald knows a previously decided value.
+        // Consensus height is the last decided height.
+        | Some(last_decided) => {
+          ...s,
+          consensus_height: last_decided.height + 1,
+          last_decided_height: last_decided.height,
+          last_decided_payload: Some(last_decided.payload)
+        }
+      }
+
+    {
+      post_state: {
+        ...s0,
+        phase: Ready,
+        consensus_round: 0
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          ConsensusReadyAction({ node: s.process_id })
+        ))
+      )
+    }
+  }
+
+  // ===== StartedRound: Enter new round =====
+  //
+  // Assumption: After ConsensusReady, on new heights, or upon a timeout,
+  // Malachite will call StartedRound informing Emerald of a new round starting.
+  // In response, Emerald will track the consensus height and round.
+
+  pure def listen_started_round(ctx: LocalContext): Set[(Height, Round)] = {
+    val s = ctx.state
+
+    val timeout =
+      ctx.events.find(e => match e {
+        | Timeout(t) => and {
+            t.height == s.consensus_height,
+            t.round == s.consensus_round,
+          }
+      })
+
+    if (timeout != None)       Set((s.consensus_height, s.consensus_round + 1))
+    else if (s.phase == Ready) Set((s.consensus_height, s.consensus_round))
+    else                       Set()
+  }
+
+  pure def handle_started_round(ctx: LocalContext, params: (Height, Round)): Transition = {
+    val s = ctx.state
+    val (height, round) = params
+
+    val proposer = proposer_for(height, round)
+
+    {
+      post_state: {
+        ...s,
+        phase: Working,
+        consensus_height: height,
+        consensus_round: round,
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          StartedRoundAction({
+            node: s.process_id,
+            height: height,
+            round: round,
+            proposer: proposer
+          })
+        ))
+      ),
+    }
+  }
+
+  // ===== GetValue: Build and propose new value =====
+  //
+  // Assumption: After starting a round, Malachite will call GetValue on the
+  // Emerald node that is the proposer for the consensus height and round. In
+  // response, Emerald will either propose a new value or return an already
+  // proposed value.
+
+  pure def listen_get_value(ctx: LocalContext): Set[()] = {
+    val s = ctx.state
+    val proposer = proposer_for(s.consensus_height, s.consensus_round)
+    if (s.phase == Working and s.process_id == proposer) Set(()) else Set()
+  }
+
+  pure def handle_get_value(ctx: LocalContext, _params: ()): Transition = {
+    val s = ctx.state
+
+    val proposal =
+      match get_local_proposal(s, s.consensus_height, s.consensus_round) {
+        | Some(proposal) => proposal
+        | None => {
+            height: s.consensus_height,
+            round: s.consensus_round,
+            proposer: s.process_id,
+            payload: next_payload(ctx)
+          }
+      }
+
+    {
+      post_state: {
+        ...s,
+        proposals: s.proposals.setAdd(proposal)
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordProposal(proposal)),
+        choreo::CustomEffect(RecordAction(
+          GetValueAction({
+            node: s.process_id,
+            height: s.consensus_height,
+            round: s.consensus_round,
+            proposal: proposal,
+          })
+        ))
+      )
+    }
+  }
+
+  // ===== ReceivedProposal: Receive a proposal =====
+  //
+  // Assumption: Malachite will call ReceivedProposal on the Emerald node,
+  // informing it of a new proposal being received for a height >=
+  // consensus_height. In response, Emerald will store the new proposal in its
+  // local state.
+
+  pure def listen_received_proposal(ctx: LocalContext): Set[Proposal] = {
+    val s = ctx.state
+
+    if (s.phase == Working)
+      ctx.extensions.all_proposals.filterMap(p => {
+        if (p.height >= s.consensus_height and not(p.in(s.proposals)))
+          Some(p)
+        else
+          None
+      })
+    else
+      Set()
+  }
+
+  pure def handle_received_proposal(ctx: LocalContext, proposal: Proposal): Transition = {
+    val s = ctx.state
+
+    {
+      post_state: {
+        ...s,
+        proposals: s.proposals.setAdd(proposal)
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          ReceivedProposalAction({
+            node: s.process_id,
+            proposal: proposal
+          })
+        ))
+      )
+    }
+  }
+
+  // ===== Decided: Commit decided value =====
+  //
+  // Assumption: Eventually a node decides on the proposal. Malachite calls
+  // Decided on an Emerald node to inform it of a decision. In response, Emerald
+  // tracks the decision and moves to the next height.
+
+  pure def listen_decided(ctx: LocalContext): Set[Proposal] = {
+    val s = ctx.state
+
+    if (s.phase == Working)
+      match get_global_decision(ctx, s.consensus_height) {
+        // There isn't a decision for the consensus height. Let's mimic
+        // Malachite consensus and have some node decide on a proposal for the
+        // consensus height and round.
+        | None =>
+            match get_local_proposal(s, s.consensus_height, s.consensus_round) {
+              | Some(p) => Set(p)
+              | None    => Set()
+            }
+        // A decision has been made for the consensus height. Let's replicate
+        // the decision as long as the Emerald node is at the same height.
+        | Some(p) =>
+            if (and {
+              p.in(s.proposals),
+              p.height == s.consensus_height
+            })
+              Set(p)
+            else
+              Set()
+      }
+    else
+      Set()
+  }
+
+  pure def handle_decided(ctx: LocalContext, decided: Proposal): Transition = {
+    val s = ctx.state
+
+    {
+      post_state: {
+        ...s,
+        // Start next height by moving back to the ready phase, which enables
+        // the handle_started_round transition.
+        phase: Ready,
+        consensus_height: decided.height + 1,
+        consensus_round: 0,
+        // Records the last decided block
+        last_decided_height: decided.height,
+        last_decided_payload: Some(decided.payload),
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordDecision((s.process_id, decided))),
+        choreo::CustomEffect(RecordAction(
+          DecidedAction({
+            node: s.process_id,
+            proposal: decided
+          })
+        ))
+      )
+    }
+  }
+
+  // ===== ProcessSyncedValue: Process synced block when catching up =====
+  //
+  // Assumption: Malachite may call ProcessSyncedValue on an Emerald node with
+  // decided proposals for the consensus heigh. In response, Emerald tracks the
+  // newly received proposal.
+  //
+  // Note that a later call to Decided is made by Malachite to confirm the
+  // received decided proposals.
+
+  pure def listen_process_synced_value(ctx: LocalContext): Set[Proposal] = {
+    val s = ctx.state
+
+    if (s.phase == Working)
+      val decided_proposal_for_height =
+        ctx.extensions.decided_proposals
+          .find(p => and {
+            p.height == s.consensus_height,
+            not(p.in(s.proposals))
+          })
+
+      match decided_proposal_for_height {
+        | Some(p) => Set(p)
+        | None    => Set()
+      }
+    else
+      Set()
+  }
+
+  pure def handle_process_synced_value(ctx: LocalContext, proposal: Proposal): Transition = {
+    val s = ctx.state
+
+    {
+      post_state: {
+        ...s,
+        proposals: s.proposals.setAdd(proposal)
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          ProcessSyncedValueAction({
+            node: s.process_id,
+            proposal: proposal
+          })
+        ))
+      )
+    }
+  }
+
+  // ===== GetDecidedValue: Provide decided value for sync =====
+  //
+  // Assumption: Malachite may call an Emerald node asking for a decision at a
+  // given height. In response, Emerald returns the decided value, if any.
+
+  pure def listen_get_decided_value(ctx: LocalContext): Set[Height] = {
+    val s = ctx.state
+
+    val max_decided_height =
+      ctx.extensions
+        .last_decided_height
+        .values()
+        .fold(0, max)
+
+    1.to(max_decided_height)
+  }
+
+  pure def handle_get_decided_value(ctx: LocalContext, height: Height): Transition = {
+    val s = ctx.state
+
+    // Note that `listen_get_decided_value` MUST only feed decided heights here.
+    val decided_proposal = get_global_decision(ctx, height).unwrap()
+
+    // Only return the decided proposal if the node knows it has been decided.
+    //
+    // Note that Emerald does not return decided proposals for the current
+    // consensus height.
+    val known_decided =
+      if (and {
+        s.consensus_height > decided_proposal.height,
+        s.last_decided_height >= decided_proposal.height
+      })
+        Some(decided_proposal)
+      else
+        None
+
+    {
+      post_state: s,
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          GetDecidedValueAction({
+            node: s.process_id,
+            height: height,
+            proposal: known_decided
+          })
+        ))
+      )
+    }
+  }
+
+  // TODO: Implement missing Malachite inputs
+  // + GetHistoryMinHeight
+  // + RestreamProposal
+  //
+  // TODO: Model additional behavior
+  // + State pruning
+
+  // ===== NodeCrash: A node crashes and comes back without any state =====
+  //
+  // Assumption: A whole node can crash at any point and lose all its data. When
+  // restarted, it catches up with others via ReceivedProposal or
+  // ProcessSyncedValue.
+
+  pure def node_crash(ctx: LocalContext): Set[Transition] = {
+    val s = ctx.state
+
+    Set({
+      post_state: initialize(s.process_id),
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          Failure({
+            node: s.process_id,
+            height: s.consensus_height,
+            mode: NodeCrash,
+          })
+        ))
+      )
+    })
+  }
+
+  // ===== NodeRestart: A node restarts but preserves its state =====
+  //
+  // Assumption: A node can restart without data loss. When restarted, it comes
+  // back at height and round zero, then ConsensusReady and StartedRound will
+  // move it back to the height it was before restarting.
+  //
+  // Note that from the perspective of model `node_restart` has the same
+  // behavior of `process_restart`, however, MBT simulates different types of
+  // failures in the test environment where the former restarts all node's
+  // processes while the latter only restarts the Emerald process.
+
+  pure def node_restart(ctx: LocalContext): Set[Transition] = {
+    val s = ctx.state
+
+    Set({
+      post_state: {
+        ...initialize(s.process_id),
+        proposals: s.proposals
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          Failure({
+            node: s.process_id,
+            height: s.consensus_height,
+            mode: NodeRestart
+          })
+        ))
+      )
+    })
+  }
+
+  // ===== ProcessRestart: The Emerald process restarts but preserves its state =====
+  //
+  // Assumption: The Emerald process can restart without data loss. When
+  // restarted, it comes back at height and round zero, then ConsensusReady and
+  // StartedRound will move it back to the height it was before restarting.
+  //
+  // Note that from the perspective of model `process_restart` has the same
+  // behavior of `node_restart`. See docs at `node_restart`.
+
+  pure def process_restart(ctx: LocalContext): Set[Transition] = {
+    val s = ctx.state
+
+    Set({
+      post_state: {
+        ...initialize(s.process_id),
+        proposals: s.proposals
+      },
+      effects: Set(
+        choreo::CustomEffect(RecordAction(
+          Failure({
+            node: s.process_id,
+            height: s.consensus_height,
+            mode: ProcessRestart
+          })
+        ))
+      )
+    })
+  }
+
+  // ===== ConsensusTimeout: A process timed out on consensus =====
+  //
+  // Assumption: Malachite may timeout while waiting for consensus on an
+  // undecided height. Then, it calls StartedRound on the Emerald node to inform
+  // of a new round starting.
+
+  pure def listen_timeout(ctx: LocalContext): Set[()] = {
+    val s = ctx.state
+    // Note that nodes that aren't working are not tracking timeouts.
+    if (s.phase == Working) Set(()) else Set()
+  }
+
+  pure def consensus_timeout(ctx: LocalContext, _params: ()): Transition = {
+    val s = ctx.state
+
+    {
+      post_state: s,
+      effects: Set(
+        choreo::TriggerEvent(Timeout({
+          height: s.consensus_height,
+          round: s.consensus_round
+        })),
+        choreo::CustomEffect(RecordAction(
+          Failure({
+            node: s.process_id,
+            height: s.consensus_height,
+            mode: ConsensusTimeout
+          })
+        ))
+      )
+    }
+  }
+
+  // =============================================================================
+  // MAIN LISTENER
+  // =============================================================================
+
+  pure def main_listener(ctx: LocalContext): Set[Transition] = {
+    Set(
+      // Initialization
+      choreo::cue(ctx, listen_consensus_ready, handle_consensus_ready),
+
+      // Round progression
+      choreo::cue(ctx, listen_started_round, handle_started_round),
+
+      // Proposal building and broadcast
+      choreo::cue(ctx, listen_get_value, handle_get_value),
+      choreo::cue(ctx, listen_received_proposal, handle_received_proposal),
+
+      // Consensus decision
+      choreo::cue(ctx, listen_decided, handle_decided),
+
+      // Synchronization protocol
+      choreo::cue(ctx, listen_process_synced_value, handle_process_synced_value),
+      choreo::cue(ctx, listen_get_decided_value, handle_get_decided_value),
+
+      // Failures
+      node_crash(ctx),
+      node_restart(ctx),
+      process_restart(ctx),
+      choreo::cue(ctx, listen_timeout, consensus_timeout)
+    ).flatten()
+  }
+
+  // =============================================================================
+  // CUSTOM EFFECT PROCESSOR
+  // =============================================================================
+
+  pure def apply_custom_effect(ctx: GlobalContext, effect: CustomEffects): GlobalContext = {
+    val ext = ctx.extensions
+
+    match effect {
+      | RecordProposal(proposal) => {
+          ...ctx,
+          extensions: {
+            ...ext,
+            all_proposals: ext.all_proposals.setAdd(proposal)
+          }
+        }
+      | RecordDecision(args) =>
+        val (node, proposal) = args
+        {
+          ...ctx,
+          extensions: {
+            ...ext,
+            decided_proposals: ext.decided_proposals.setAdd(proposal),
+            last_decided_height: ext.last_decided_height.put(node, proposal.height)
+          }
+        }
+      | RecordAction(action_taken) =>
+          val ext = {
+            ...ctx.extensions,
+            action_taken: action_taken
+          }
+
+          val ext0 = match action_taken {
+            | Failure(args) =>
+                val { node, height, mode } = args
+                val s = ctx.system.get(node)
+                {
+                  ...ext,
+                  failures: ext.failures.setAdd(args),
+                  // Note that during a node crash, the node loses track of its
+                  // last decided height and restarts from genesis.
+                  last_decided_height:
+                    if (mode == NodeCrash)
+                      ext.last_decided_height.put(node, 0)
+                    else
+                      ext.last_decided_height
+                }
+            | _ => ext
+          }
+
+          {
+            ...ctx,
+            extensions: {
+              ...ext0,
+              action_taken: action_taken
+            }
+          }
+    }
+  }
+
+  // =============================================================================
+  // INITIALIZATION
+  // =============================================================================
+
+  pure def initialize(node: Node): LocalState = 
+    {
+      process_id: node,
+      phase: Uninitialized,
+      consensus_height: 0,
+      consensus_round: 0,
+      proposals: Set(),
+      last_decided_height: 0,
+      last_decided_payload: None
+    }
+
+  action init =
+    val nodes = NODES.toSet()
+    choreo::init({
+      system: nodes.mapBy(n => initialize(n)),
+      messages: nodes.mapBy(n => Set()),
+      events: nodes.mapBy(n => Set()),
+      extensions: {
+        action_taken: InitAction,
+        all_proposals: Set(),
+        decided_proposals: Set(),
+        last_decided_height: nodes.mapBy(n => 0),
+        failures: Set()
+      }
+    })
+
+  // =============================================================================
+  // STEP FUNCTIONS
+  // =============================================================================
+
+  action step = choreo::step(main_listener, apply_custom_effect)
+
+  action step_with_filter(f: (LocalContext, Transition) => bool): bool =
+    choreo::step(ctx => main_listener(ctx).filter(t => f(ctx, t)), apply_custom_effect)
+
+  // =============================================================================
+  // PROPERTIES AND INVARIANTS
+  // =============================================================================
+
+  // Safety: All nodes agree on decided blocks.
+  val agreement =
+    NODES.toSet().forall(n1 =>
+      NODES.toSet().forall(n2 =>
+        val st1 = choreo::convert_context(choreo::s, n1).state
+        val st2 = choreo::convert_context(choreo::s, n2).state
+
+        st1.last_decided_height == st2.last_decided_height implies
+          st1.last_decided_payload == st2.last_decided_payload
+      )
+    )
+
+  // Assumption: All nodes know decided proposals.
+  val completion =
+    NODES.toSet().forall(n =>
+      val ctx = choreo::convert_context(choreo::s, n)
+      val st = ctx.state
+
+      1.to(st.last_decided_height).forall(height =>
+        val decided = get_global_decision(ctx, height).unwrap()
+        decided.in(st.proposals)
+      )
+    )
+
+  // Assumption: After initialization, Emerald's consensus height IS ALWAYS
+  // greater than the last decided height.
+  val consensus_height_gt_last_decided_height =
+    NODES.toSet().forall(n =>
+      val st = choreo::convert_context(choreo::s, n).state
+
+      st.consensus_height > 0 implies
+        st.consensus_height > st.last_decided_height
+    )
+
+  // =============================================================================
+  // WIRING CHOREO FOR TESTING
+  // =============================================================================
+
+  val s = choreo::s
+
+  def with_cue(process, listen_fn, params) =
+    choreo::with_cue(process, listen_fn, params)
+
+  action perform(cue_ctx, upon_fn) =
+    choreo::perform(cue_ctx, upon_fn, apply_custom_effect)
+
+  action step_with(node: Node, listener: LocalContext => Set[Transition]): bool =
+    choreo::step_with(node, listener, apply_custom_effect)
+}

--- a/specs/emerald_mbt.qnt
+++ b/specs/emerald_mbt.qnt
@@ -1,0 +1,74 @@
+// -*- mode: Bluespec; -*-
+
+// =============================================================================
+// Emerald Model-Based Tests Specification
+// =============================================================================
+//
+// This is a refinement of the Emerald specification for model-based testing
+// (MBT) purposes.
+//
+// This spec guides MBT exploration into realistic scenarios by limiting the
+// amount of failures per run. Without such limitations, traces can get stuck on
+// crashes or restarts, preventing the exploration from covering more diverse
+// behavioral cases.
+//
+// Note that this spec inherits `init` and `step` from the more general Emerald
+// spec. To use the filtered step transitions, run it with `--step
+// step_no_failures` or `--step step_with_failures`.
+//
+// ```
+// quint run emerald_mbt.qnt --step step_no_failures --invariant="agreement"
+// ```
+
+module emerald_mbt {
+  import basicSpells.* from "spells/basicSpells"
+  import emerald_types.* from "emerald_types"
+  import emerald(NODES = List("node1", "node2", "node3")).* from "emerald"
+
+  // Helper: Given a state transition, return which action was taken by it.
+  pure def get_action_taken(t: Transition): ActionTaken =
+    t.effects
+      .filterMap(eff => match eff {
+        | CustomEffect(ceff) => match ceff {
+            | RecordAction(act) => Some(act)
+            | _                 => None
+          }
+        | _ => None
+      })
+      .getOnlyElement()
+
+
+  // A transition filter that rejects all failure actions
+  pure def no_failures_filter(ctx: LocalContext, t: Transition): bool =
+    match get_action_taken(t) {
+      | Failure(args) => false
+      | _             => true
+    }
+
+  // A transition filter that allows at most one failure per (node, height)
+  // pair. Note that it rejects failures at height == 0 (uninitialized nodes).
+  pure def one_failure_per_height(ctx: LocalContext, t: Transition): bool = {
+    val s = ctx.state
+    val ext = ctx.extensions
+
+    match get_action_taken(t) {
+      | Failure(args) => {
+          val last_failure_in_height =
+            ext.failures
+              .find(c => and {
+                c.node == s.process_id,
+                c.height == s.consensus_height
+              })
+
+          and {
+            s.consensus_height > 0,
+            last_failure_in_height == None
+          }
+        }
+      | _ => true
+    }
+  }
+
+  action step_no_failures = step_with_filter(no_failures_filter)
+  action step_with_failures = step_with_filter(one_failure_per_height)
+}

--- a/specs/emerald_tests.qnt
+++ b/specs/emerald_tests.qnt
@@ -1,0 +1,256 @@
+// -*- mode: Bluespec; -*-
+
+// =============================================================================
+// Emerald Specification Tests
+// =============================================================================
+//
+// This module contains deterministic test scenarios for the Emerald
+// specification, validating specific execution paths through the protocol's
+// state machine.
+//
+// Note that tests are prefixed with "emerald" in order to isolate them from
+// tests in other imported Quint modules. Run Emerald-only tests with:
+//
+// ```
+// quint test emerald_tests.qnt --match "emerald"
+// ```
+
+module emerald_tests {
+  import basicSpells.* from "spells/basicSpells"
+  import rareSpells.* from "spells/rareSpells"
+  import emerald_types.* from "emerald_types"
+  import emerald(NODES = List("node1", "node2", "node3")).* from "emerald"
+
+  // =============================================================================
+  // MALACHITE INPUTS
+  // =============================================================================
+
+  run consensusReady(node: Node, height: Height, round: Round): bool =
+    node
+      .with_cue(listen_consensus_ready, ())
+      .perform(handle_consensus_ready)
+      .expect(
+        val st = s.system.get(node)
+        and {
+          st.phase == Ready,
+          st.consensus_height == height,
+          st.consensus_round == round
+        }
+      )
+
+  run startedRound(node: Node, height: Height, round: Round): bool =
+    node
+      .with_cue(listen_started_round, (height, round))
+      .perform(handle_started_round)
+      .expect(s.system.get(node).phase == Working)
+
+  run getValue(node: Node, proposal: Proposal): bool =
+    node
+      .with_cue(listen_get_value, ())
+      .perform(handle_get_value)
+      .expect(proposal.in(s.system.get(node).proposals))
+
+  run receivedProposal(node: Node, proposal: Proposal): bool =
+    node
+      .with_cue(listen_received_proposal, proposal)
+      .perform(handle_received_proposal)
+      .expect(proposal.in(s.system.get(node).proposals))
+
+  run decided(node: Node, proposal: Proposal): bool =
+    node
+      .with_cue(listen_decided, proposal)
+      .perform(handle_decided)
+      .expect(
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == proposal.height,
+          st.last_decided_payload == Some(proposal.payload),
+          st.consensus_height == proposal.height + 1,
+          st.consensus_round == 0,
+          st.phase == Ready
+        }
+      )
+
+  run processSyncedValue(node: Node, proposal: Proposal): bool =
+    node
+      .with_cue(listen_process_synced_value, proposal)
+      .perform(handle_process_synced_value)
+      .expect(proposal.in(s.system.get(node).proposals))
+
+  // =============================================================================
+  // FAILURES
+  // =============================================================================
+
+  run timeout(node: Node, height: Height, round: Round): bool =
+    node
+      .with_cue(listen_timeout, ())
+      .perform(consensus_timeout)
+      .expect(
+        val timeout = Timeout({ height: height, round: round })
+        timeout.in(s.events.get(node))
+      )
+
+  run crash(node: Node): bool =
+    node
+      .step_with(node_crash)
+      .expect(s.system.get(node) == initialize(node))
+
+  run restart(node: Node): bool =
+    node
+      .step_with(process_restart)
+      .expect(
+        val st = s.system.get(node)
+        and {
+          st.phase == Uninitialized,
+          st.consensus_height == 0,
+          st.consensus_round == 0
+        }
+      )
+
+  // =============================================================================
+  // HELPER RUNS AND FUNCTIONS
+  // =============================================================================
+
+  pure def proposal(height: Height, round: Round, payload: Payload): Proposal =
+    {
+      height: height,
+      round: round,
+      payload: payload,
+      proposer: proposer_for(height, round)
+    }
+
+  // All nodes start from genesis
+  run genesisStart =
+    init
+      .then("node1".consensusReady(1, 0))
+      .then("node2".consensusReady(1, 0))
+      .then("node3".consensusReady(1, 0))
+      .expect(
+        NODES.toSet().forall(node =>
+           val st = s.system.get(node)
+           and {
+             st.last_decided_height == 0,
+             st.last_decided_payload == None,
+             st.proposals.size() == 0
+           }
+         )
+      )
+      .then("node1".startedRound(1, 0))
+      .then("node2".startedRound(1, 0))
+      .then("node3".startedRound(1, 0))
+      .expect(proposer_for(1, 0) == "node1")
+
+  // Nodes 1 and 2 decided on heights 1 and 2 while node 3 stalled
+  run node3Stalled =
+    genesisStart
+      .then("node1".getValue(proposal(1, 0, 0)))
+      .then("node2".receivedProposal(proposal(1, 0, 0)))
+      .then("node1".decided(proposal(1, 0, 0)))
+      .then("node2".decided(proposal(1, 0, 0)))
+      .then("node1".startedRound(2, 0))
+      .then("node2".startedRound(2, 0))
+      .expect(proposer_for(2, 0) == "node2")
+      .then("node2".getValue(proposal(2, 0, 1)))
+      .then("node1".receivedProposal(proposal(2, 0, 1)))
+      .then("node2".decided(proposal(2, 0, 1)))
+      .then("node1".decided(proposal(2, 0, 1)))
+
+  // =============================================================================
+  // TEST SCENARIOS
+  // =============================================================================
+
+  // Happy path: all nodes decided on a single height
+  run emeraldSingleHeightConsensusTest =
+    genesisStart
+      .then("node1".getValue(proposal(1, 0, 0)))
+      .then("node2".receivedProposal(proposal(1, 0, 0)))
+      .then("node3".receivedProposal(proposal(1, 0, 0)))
+      .then("node1".decided(proposal(1, 0, 0)))
+      .then("node2".decided(proposal(1, 0, 0)))
+      .then("node3".decided(proposal(1, 0, 0)))
+      .expect(NODES.toSet().forall(node =>
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == 1,
+          st.last_decided_payload == Some(0)
+        }
+      ))
+
+  // Unhappy path: nodes decide after a consensus timeout
+  run emeraldTimeoutAndDecideTest =
+    genesisStart
+      .then("node1".getValue(proposal(1, 0, 0)))
+      .then("node1".timeout(1, 0))
+      .then("node2".timeout(1, 0))
+      .then("node3".timeout(1, 0))
+      .then("node1".startedRound(1, 1))
+      .then("node2".startedRound(1, 1))
+      .then("node3".startedRound(1, 1))
+      .expect(proposer_for(1, 1) == "node2")
+      .then("node2".getValue(proposal(1, 1, 1)))
+      .then("node1".receivedProposal(proposal(1, 1, 1)))
+      .then("node3".receivedProposal(proposal(1, 1, 1)))
+      .then("node2".decided(proposal(1, 1, 1)))
+      .then("node1".decided(proposal(1, 1, 1)))
+      .then("node3".decided(proposal(1, 1, 1)))
+      .expect(NODES.toSet().forall(node =>
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == 1,
+          st.last_decided_payload == Some(1)
+        }
+      ))
+
+  // Unhappy path: stalled node catches up on consensus
+  run emeraldStalledNodeCatchesUpViaSyncTest =
+    node3Stalled
+      .then("node3".processSyncedValue(proposal(1, 0, 0)))
+      .then("node3".decided(proposal(1, 0, 0)))
+      .then("node3".startedRound(2, 0))
+      .then("node3".processSyncedValue(proposal(2, 0, 1)))
+      .then("node3".decided(proposal(2, 0, 1)))
+      .expect(NODES.toSet().forall(node =>
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == 2,
+          st.last_decided_payload == Some(1)
+        }
+      ))
+
+  // Unhappy path: stalled node catches up after crash
+  run emeraldStalledNodeCatchesUpAfterCrashTest =
+    node3Stalled
+      .then("node3".crash())
+      .then("node3".consensusReady(1, 0))
+      .then("node3".startedRound(1, 0))
+      .then("node3".processSyncedValue(proposal(1, 0, 0)))
+      .then("node3".decided(proposal(1, 0, 0)))
+      .then("node3".startedRound(2, 0))
+      .then("node3".processSyncedValue(proposal(2, 0, 1)))
+      .then("node3".decided(proposal(2, 0, 1)))
+      .expect(NODES.toSet().forall(node =>
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == 2,
+          st.last_decided_payload == Some(1)
+        }
+      ))
+
+  // Unhappy path: stalled node catches up after a restart
+  run emeraldStalledNodeCatchesUpAfterRestartTest =
+    node3Stalled
+      .then("node3".processSyncedValue(proposal(1, 0, 0)))
+      .then("node3".decided(proposal(1, 0, 0)))
+      .then("node3".restart())
+      .then("node3".consensusReady(2, 0))
+      .then("node3".startedRound(2, 0))
+      .then("node3".processSyncedValue(proposal(2, 0, 1)))
+      .then("node3".decided(proposal(2, 0, 1)))
+      .expect(NODES.toSet().forall(node =>
+        val st = s.system.get(node)
+        and {
+          st.last_decided_height == 2,
+          st.last_decided_payload == Some(1)
+        }
+      ))
+}

--- a/specs/emerald_types.qnt
+++ b/specs/emerald_types.qnt
@@ -1,0 +1,129 @@
+// -*- mode: Bluespec; -*-
+
+// =============================================================================
+// Emerald Type Definitions
+// =============================================================================
+//
+// This specification contains type definitions used across various Emerald
+// specifications.
+
+module emerald_types {
+  import basicSpells.* from "spells/basicSpells"
+
+  // =============================================================================
+  // PROTOCOL-SPECIFIC TYPES
+  // =============================================================================
+
+  // A consensus height
+  type Height = int
+
+  // A consensus round within a given height
+  type Round = int
+
+  // A block's payload
+  type Payload = int
+
+  // The application's current phase.
+  //
+  // These phases model different stages in the application lifecycle. Emerald
+  // nodes start "Uninitialized", then move to "Ready" once Malachite starts
+  // (ConsensusReady), and from "Ready" to "Working" after Malachite informs
+  // Emerald of a new round starting (StartedRound).
+  //
+  // During normal operation, Emerald moves back to "Ready" at the end of each
+  // consensus height (Decided), then back to "Working" once the new height
+  // starts (StartedRound).
+  type AppPhase =
+    | Uninitialized // Before ConsensusReady
+    | Ready         // After ConsensusReady or Decided, before StartedRound
+    | Working       // After StartedRound
+
+  // A consensus proposal
+  type Proposal = {
+    height: Height,
+    round: Round,
+    proposer: Node,
+    payload: Payload,
+  }
+
+  // =============================================================================
+  // CHOREO AND MBT TYPE DEFINITIONS
+  // =============================================================================
+
+  type Node = str
+
+  // Note: this specification does not model message exchanges between nodes as
+  // those are Malachite's responsibility.
+  type Message = ()
+
+  type Event =
+    // Consensus timeouts are modeled as events, which in return trigger the
+    // start of new rounds. (see listen_started_round).
+    | Timeout({ height: Height, round: Round })
+
+  type CustomEffects =
+    // Records the existence of a new proposal.
+    | RecordProposal(Proposal)
+    // Records the commit of a given proposal.
+    | RecordDecision((Node, Proposal))
+    // Records which action was taken by the model for MBT.
+    | RecordAction(ActionTaken)
+
+  // Actions taken by the model for MBT.
+  //
+  // Variants must either have no arguments or a single object as an argument.
+  // Object fields become available in the test code using the Quint Connect
+  // library.
+  type ActionTaken =
+    | InitAction
+    | ConsensusReadyAction({ node: Node })
+    | StartedRoundAction({ node: Node, height: Height, round: Round, proposer: Node })
+    | GetValueAction({ node: Node, height: Height, round: Round, proposal: Proposal })
+    | ReceivedProposalAction({ node: Node, proposal: Proposal })
+    | DecidedAction({ node: Node, proposal: Proposal })
+    | ProcessSyncedValueAction({ node: Node, proposal: Proposal })
+    | GetDecidedValueAction({ node: Node, height: Height, proposal: Option[Proposal] })
+    | Failure({ node: Node, mode: FailureMode, height: Height })
+
+  // Different forms of node failure the service can experience.
+  //
+  // Note that NodeRestart and ProcessRestart are the same failure wrt. the
+  // model, but MBT distinguishes them by restarting the process or the node
+  // when testing.
+  type FailureMode =
+    // The whole node (all processes) has crashed and lost its data
+    | NodeCrash
+    // The whole node (all processes) has restarted without data loss
+    | NodeRestart
+    // The Emerald process has restarted without data loss
+    | ProcessRestart
+    // Consensus has timed out.
+    | ConsensusTimeout
+
+  // Local state for each Emerald node
+  type StateFields = {
+    phase: AppPhase,
+    // Consensus state
+    consensus_height: Height,
+    consensus_round: Round,
+    // Last committed block
+    last_decided_height: Height,
+    last_decided_payload: Option[Payload],
+    // Node's known proposals
+    proposals: Set[Proposal],
+  }
+
+  // Global state for inter-node communication and MBT
+  type Extensions = {
+    // Track all proposals
+    all_proposals: Set[Proposal],
+    // Track decided proposals
+    decided_proposals: Set[Proposal],
+    // Track node's last decided height
+    last_decided_height: Node -> Height,
+    // Track the action taken for MBT
+    action_taken: ActionTaken,
+    // Track the set of failures that occurred
+    failures: Set[{node: Node, height: Height, mode: FailureMode}]
+  }
+}

--- a/specs/spells/basicSpells.qnt
+++ b/specs/spells/basicSpells.qnt
@@ -1,0 +1,389 @@
+// -*- mode: Bluespec; -*-
+/**
+ * This module collects definitions that are ubiquitous.
+ * One day they will become the standard library of Quint.
+ */
+module basicSpells {
+  /// Option type, which may hold some value or none
+  type Option[a] = Some(a) | None
+
+  /// An annotation for writing preconditions.
+  /// - @param cond condition to check
+  /// - @returns true if and only if cond evaluates to true
+  pure def require(cond: bool): bool = cond
+
+  run requireTest = all {
+    assert(require(4 > 3)),
+    assert(not(require(false))),
+  }
+
+  /// A convenience operator that returns a string error code,
+  ///  if the condition does not hold true.
+  ///
+  /// - @param cond condition to check
+  /// - @param error a non-empty error message
+  /// - @returns "", when cond holds true; otherwise error
+  pure def requires(cond: bool, error: str): str = {
+    if (cond) "" else error
+  }
+
+  run requiresTest = all {
+    assert(requires(4 > 3, "4 > 3") == ""),
+    assert(requires(4 < 3, "false: 4 < 3") == "false: 4 < 3"),
+  }
+
+
+  /// Compute the maximum of two integers.
+  ///
+  /// - @param i first integer
+  /// - @param j second integer
+  /// - @returns the maximum of i and j
+  pure def max(i: int, j: int): int = {
+    if (i > j) i else j
+  }
+
+  run maxTest = all {
+    assert(max(3, 4) == 4),
+    assert(max(6, 3) == 6),
+    assert(max(10, 10) == 10),
+    assert(max(-3, -5) == -3),
+    assert(max(-5, -3) == -3),
+  }
+
+  /// Compute the minimum of two integers.
+  ///
+  /// - @param i first integer
+  /// - @param j second integer
+  /// - @returns the minimum of i and j
+  pure def min(i: int, j: int): int = {
+    if (i < j) i else j
+  }
+
+  run minTest = all {
+    assert(min(3, 4) == 3),
+    assert(min(6, 3) == 3),
+    assert(min(10, 10) == 10),
+    assert(min(-3, -5) == -5),
+    assert(min(-5, -3) == -5),
+  }
+
+  /// Compute the absolute value of an integer
+  ///
+  /// - @param i : an integer whose absolute value we are interested in
+  /// - @returns |i|, the absolute value of i
+  pure def abs(i: int): int = {
+    if (i < 0) -i else i
+  }
+
+  run absTest = all {
+    assert(abs(3) == 3),
+    assert(abs(-3) == 3),
+    assert(abs(0) == 0),
+  }
+
+  /// Remove a set element.
+  ///
+  /// - @param s a set to remove an element from
+  /// - @param elem an element to remove
+  /// - @returns a new set that contains all elements of set but elem
+  pure def setRemove(s: Set[a], elem: a): Set[a] = {
+    s.exclude(Set(elem))
+  }
+
+  run setRemoveTest = all {
+    assert(Set(2, 4) == Set(2, 3, 4).setRemove(3)),
+    assert(Set() == Set().setRemove(3)),
+  }
+
+  /// Adds an element to a set.
+  ///
+  /// - @param s a set to add an element to
+  /// - @param elem an element to add
+  /// - @returns a new set that contains all elements of set and elem
+  pure def setAdd(s: Set[a], elem: a): Set[a] = {
+    s.union(Set(elem))
+  }
+
+  run setAddTest = all{
+    assert(Set(2, 3, 4) == Set(2, 4).setAdd(3)),
+    assert(Set(3) == Set().setAdd(3)),
+    assert(Set(2,4) == Set(2,4).setAdd(4)),
+  }
+
+  /// Test whether a key is present in a map
+  ///
+  /// - @param m a map to query
+  /// - @param key the key to look for
+  /// - @returns true if and only map has an entry associated with key
+  pure def has(m: a -> b, key: a): bool = {
+    m.keys().contains(key)
+  }
+
+  run hasTest = all {
+    assert(Map(2 -> 3, 4 -> 5).has(2)),
+    assert(not(Map(2 -> 3, 4 -> 5).has(6))),
+  }
+
+  /// Get the map value associated with a key, or the default,
+  /// if the key is not present.
+  ///
+  /// - @param m the map to query
+  /// - @param key the key to search for
+  /// - @returns the value associated with the key, if key is
+  ///   present in the map, and default otherwise
+  pure def getOrElse(m: a -> b, key: a, default: b): b = {
+    if (m.has(key)) {
+      m.get(key)
+    } else {
+      default
+    }
+  }
+
+  run getOrElseTest = all {
+    assert(Map(2 -> 3, 4 -> 5).getOrElse(2, 0) == 3),
+    assert(Map(2 -> 3, 4 -> 5).getOrElse(7, 11) == 11),
+  }
+
+  /// Remove a map entry.
+  ///
+  /// - @param m a map to remove an entry from
+  /// - @param key the key of an entry to remove
+  /// - @returns a new map that contains all entries of map
+  ///          that do not have the key key
+  pure def mapRemove(m: a -> b, key: a): a -> b = {
+    m.keys().setRemove(key).mapBy(k => m.get(k))
+  }
+
+  run mapRemoveTest = all {
+    assert(Map(3 -> 4, 7 -> 8) == Map(3 -> 4, 5 -> 6, 7 -> 8).mapRemove(5)),
+    assert(Map() == Map().mapRemove(3)),
+  }
+
+  /// Removes a set of map entries.
+  ///
+  /// - @param m a map to remove entries from
+  /// - @param ks a set of keys for entries to remove from the map
+  /// - @returns a new map that contains all entries of map
+  ///          that do not have a key in keys
+  pure def mapRemoveAll(m: a -> b, ks: Set[a]): a -> b = {
+      m.keys().exclude(ks).mapBy(k => m.get(k))
+  }
+
+  run mapRemoveAllTest =
+      val m = Map(3 -> 4, 5 -> 6, 7 -> 8)
+      all {
+          assert(m.mapRemoveAll(Set(5, 7)) == Map(3 -> 4)),
+          assert(m.mapRemoveAll(Set(5, 99999)) == Map(3 -> 4, 7 -> 8)),
+      }
+
+  /// Get the set of values of a map.
+  ///
+  /// - @param map a map from type a to type b
+  /// - @returns the set of all values in the map
+  pure def values(m: a -> b): Set[b] = {
+    m.keys().map(k => m.get(k))
+  }
+
+  run valuesTest = all {
+    assert(values(Map()) == Set()),
+    assert(values(Map(1 -> 2, 2 -> 3)) == Set(2, 3)),
+    assert(values(Map(1 -> 2, 2 -> 3, 3 -> 2)) == Set(2, 3)),
+  }
+
+  /// Whether a set is empty
+  ///
+  /// - @param s a set of any type
+  /// - @returns true iff the set is the empty set
+  pure def empty(s: Set[a]): bool = s == Set()
+
+  run emptyTest = all {
+    assert(empty(Set()) == true),
+    assert(empty(Set(1, 2)) == false),
+    assert(empty(Set(Set())) == false),
+  }
+
+  /// Sort a list, given the ordering operator.
+  ///
+  /// - @param list a list to sort
+  /// - @param lt a definition of "less than"
+  /// - @returns the sorted version of list
+  pure def sortList(list: List[a], lt: (a, a) => bool): List[a] = {
+    pure def insertInOrder(sortedList: List[a], num: a): List[a] = {
+      match range(0, sortedList.length()).findFirst(i => not(lt(sortedList[i], num))) {
+        | None => sortedList.append(num)
+        | Some(index) => sortedList.slice(0, index).append(num).concat(sortedList.slice(index, sortedList.length()))
+      }
+    }
+
+    list.foldl([], (sortedList, num) => insertInOrder(sortedList, num))
+  }
+
+  run listSortedTest = all {
+    assert([ 1, 3, 5 ] == sortList([ 5, 1, 3 ], (x, y) => x < y)),
+    assert([ 1, 1, 3, 5, 5 ] == sortList([ 5, 1, 3, 1, 5 ], (x, y) => x < y)),
+  }
+
+  /// Apply an operator to all values of a map
+  ///
+  /// - @param m: a map of any type
+  /// - @param f: an operator with one argument with the same type as the map's values
+  /// - @returns a map with same keys as m and f applied to the values
+  pure def transformValues(m: a -> b, f: (b) => c): a -> c = {
+    m.keys().mapBy(k => f(m.get(k)))
+  }
+
+  run transformValuesTest = {
+    pure val m = Map("a" -> 1, "b" -> 2)
+    assert(m.transformValues(x => x + 1) == Map("a" -> 2, "b" -> 3))
+  }
+
+  /// map a function over a list
+  ///
+  /// - @param l: a list of any type
+  /// - @param f: a function to apply to each element of the list
+  /// - @returns a list of the results of applying f to each element of l
+  pure def listMap(l: List[a], f: (a) => b): List[b] = {
+    range(0, l.length()).foldl([], (acc, i) => {
+      acc.append(f(l[i]))
+    })
+  }
+
+  run listMapTest = all {
+    assert(listMap([1, 2, 3], x => x + 1) == [2, 3, 4]),
+    assert(listMap([1, 2, 3], x => x > 1) == [false, true, true]),
+  }
+
+  /// The last element of a list
+  ///
+  /// - @param v: a list of any type
+  /// - @returns the last element of the list
+  pure def last(v: List[a]): a = {
+    v[v.length() - 1]
+  }
+
+  run lastTest = all {
+    assert(last([1, 2, 3]) == 3),
+    assert(last([1]) == 1),
+  }
+
+  /// `decreasingRange(i, j)` is the list of integers between `j` and `i`
+  /// both `i` and `j` are inclusive.
+  /// The behavior is undefined if `i < j`.
+  ///
+  /// - @param start: the first integer in the range
+  /// - @param end: the last integer in the range
+  pure def decreasingRange(start: int, end: int): List[int] = {
+    range(end, start + 1).foldl([], (acc, i) => {
+      List(i).concat(acc)
+    })
+  }
+
+  run decreasingRangeTest = all {
+    assert(decreasingRange(5, 1) == [5, 4, 3, 2, 1]),
+  }
+
+  /// `takeWhile(l, cond)` is the longest prefix of `l` such that all elements
+  /// satisfy the condition `cond`.
+  ///
+  /// - @param l: a list of any type
+  /// - @param cond: a function that takes an element of the list and returns a boolean
+  /// - @returns the longest prefix of `l` such that all elements satisfy `cond`
+  pure def takeWhile(l: List[a], cond: (a) => bool): List[a] = {
+    pure val result = l.foldl(([], true), (acc, e) => {
+      if (acc._2 and cond(e)) {
+        (acc._1.append(e), true)
+      } else {
+        (acc._1, false)
+      }
+    })
+
+    result._1
+  }
+
+  run takeWhileTest = all {
+    assert(takeWhile([1, 5, 4, 3], (x) => x % 2 == 1) == [1, 5]),
+  }
+
+  /// `isPrefixOf(l1, l2)` is true iff `l1` is a prefix of `l2`.
+  ///
+  /// - @param l1: a list of any type
+  /// - @param l2: a list of same type as `l1`
+  /// - @returns true iff `l1` is a prefix of `l2`
+  pure def isPrefixOf(l1: List[a], l2: List[a]): bool = {
+    if (l1.length() > l2.length()) {
+      false
+    } else {
+      l1.indices().forall(i => l1[i] == l2[i])
+    }
+  }
+
+  run isPrefixOfTest = all {
+    assert(isPrefixOf([1, 2], [1, 2, 3])),
+    assert(not(isPrefixOf([1, 2], [1, 3, 2]))),
+    assert(not(isPrefixOf([1, 2], [1]))),
+    assert(isPrefixOf([], [1, 2])),
+    assert(isPrefixOf([], [])),
+  }
+
+  /// `find(s, f)` is an element of `s` that satisfies the predicate `f`, or None
+  /// if no such element exists.
+  ///
+  /// - @param s: a set of any type
+  /// - @param f: a function that takes an element of the set and returns a boolean
+  /// - @returns an element of `s` that satisfies `f`, or None
+  pure def find(s, f) = s.fold(None, (a, i) => if (f(i)) Some(i) else a)
+
+  run findTest = all {
+    assert(find(Set(1, 2, 3), x => x == 2) == Some(2)),
+    assert(find(Set(1, 2, 3), x => x == 4) == None),
+  }
+
+  /// `findFirst(l, f)` is the first element of `l` that satisfies the predicate `f`, or None
+  /// if no such element exists.
+  ///
+  /// - @param l: a list of any type
+  /// - @param f: a function that takes an element of the list and returns a boolean
+  /// - @returns the first element of `l` that satisfies `f`, or None
+  pure def findFirst(l, f) = l.foldl(None, (a, i) => if (a == None and f(i)) Some(i) else a)
+
+  run findFirstTest = all {
+    assert(findFirst([1, 2, 3], x => x > 1) == Some(2)),
+    assert(findFirst([1, 2, 3], x => x == 4) == None),
+  }
+
+  /// `setByWithDefault(m, k, op, default)` is a map that is the same as `m` except that
+  /// the value associated with `k` is `op(m[k])` if `k` is present in `m`, and `op(default)` otherwise.
+  ///
+  /// - @param m: a map from type `a` to type `b`
+  /// - @param k: a key of type `a`
+  /// - @param op: a function to transform the value of the key
+  /// - @param default: the value to use if the key is not present in the map
+  /// - @returns a new map with the updated key.
+  pure def setByWithDefault(m: a -> b, k: a, op: (b) => b, default: b): a -> b = {
+    if (m.has(k))
+      m.setBy(k, op)
+    else
+      m.put(k, default).setBy(k, op)
+  }
+
+  run setByWithDefaultTest = all {
+    assert(setByWithDefault(Map(1 -> 2, 2 -> 3), 1, x => x + 1, 0) == Map(1 -> 3, 2 -> 3)),
+    assert(setByWithDefault(Map(1 -> 2, 2 -> 3), 3, x => x + 1, 0) == Map(1 -> 2, 2 -> 3, 3 -> 1)),
+  }
+
+  pure def unwrap(value: Option[a]): a = {
+    match value {
+      | None => Map().get(value)
+      | Some(x) => x
+    }
+  }
+
+  pure def filterMap(s: Set[a], f: (a) => Option[b]): Set[b] = {
+    s.fold(Set(), (acc, e) => {
+      match f(e) {
+        | Some(x) => acc.union(Set(x))
+        | None => acc
+      }
+    })
+  }
+}

--- a/specs/spells/rareSpells.qnt
+++ b/specs/spells/rareSpells.qnt
@@ -1,0 +1,110 @@
+// -*- mode: Bluespec; -*-
+/**
+ * This is a collection of rare spells. When we see some of these spells
+ * appearing in multiple specs, we would move them to commonSpells.
+ *
+ * If you use the same definition in several specifications, and you believe
+ * that it could be useful for other people, consider contributing your
+ * definition to the rare spells. Do not forget to add a test for your spell,
+ * so the others would see how to use it.
+ */
+module rareSpells {
+
+  /// The type of orderings between comparable things
+  // Follows https://hackage.haskell.org/package/base-4.19.0.0/docs/Data-Ord.html#t:Ordering
+  // and we think there are likely benefits to using 3 constant values rather than the more
+  // common integer range in Apalache.
+  type Ordering =
+    | EQ
+    | LT
+    | GT
+
+  /// Comparison of integers
+  pure def intCompare(__a: int, __b:int): Ordering = {
+    if (__a < __b)
+      { LT }
+    else if (__a > __b)
+      { GT }
+    else
+      { EQ }
+  }
+
+  ///
+  /// Compute the sum of the values over all entries in a map.
+  ///
+  /// - @param myMap a map from keys to integers
+  /// - @returns the sum; when the map is empty, the sum is 0.
+  pure def mapValuesSum(myMap: a -> int): int = {
+    myMap.keys().fold(0, ((sum, i) => sum + myMap.get(i)))
+  }
+
+  run mapValuesSumTest = all {
+    assert(Map().mapValuesSum() == 0),
+    assert(2.to(5).mapBy(i => i * 2).mapValuesSum() == 28),
+    assert(Map(2 -> -4, 4 -> 2).mapValuesSum() == -2),
+  }
+
+  /// Assuming `__l` is sorted according to `__cmp`, returns a list with the element `__x`
+  /// insterted in order.
+  ///
+  /// If `__l` is not sorted, `__x` will be inserted after the first element less than
+  /// or equal to it.
+  ///
+  /// - @param __l a sorted list
+  /// - @param __x an element to be inserted
+  /// - @param __cmp an operator defining an `Ordering` of the elemnts of type `a`
+  /// - @returns a sorted list that includes `__x`
+  pure def sortedListInsert(__l: List[a], __x: a, __cmp: (a, a) => Ordering): List[a] = {
+    // We need to track whether __x has been inserted, and the accumulator for the new list
+    val __init = { is_inserted: false, acc: List() }
+
+    val __result = __l.foldl(__init, (__state, __y) =>
+      if (__state.is_inserted)
+        { ...__state, acc: __state.acc.append(__y) }
+      else
+        match __cmp(__x, __y) {
+          | GT => { ...__state, acc: __state.acc.append(__y) }
+          | _  => { is_inserted: true, acc: __state.acc.append(__x).append(__y)  }
+        })
+
+    if (not(__result.is_inserted))
+      // If __x was not inserted, it was GT than every other element, so it goes at the end
+      __result.acc.append(__x)
+    else
+      __result.acc
+  }
+
+  run sortedListInsertTest = all {
+    assert(List().sortedListInsert(3, intCompare) == List(3)),
+    assert(List(1,2,4).sortedListInsert(3, intCompare) == List(1,2,3,4)),
+    assert(List(4,1,2).sortedListInsert(3, intCompare) == List(3,4,1,2)),
+  }
+
+  //// Returns a list of all elements of a set.
+  //// The ordering will be arbitrary.
+  ////
+  //// - @param __set a set
+  //// - @param __cmp an ordering over the elements of the set
+  //// - @returns a sorted list of all elements of __set
+  pure def toList(__set: Set[a], __cmp: (a, a) => Ordering): List[a] = {
+      __set.fold(List(), (__l, __e) => __l.sortedListInsert(__e, __cmp))
+  }
+
+  //// Returns a set of the elements in the list.
+  ////
+  //// - @param __list a list
+  //// - @returns a set of the elements in __list
+  pure def toSet(__list: List[a]): Set[a] = {
+      __list.foldl(Set(), (__s, __e) => __s.union(Set(__e)))
+  }
+
+  run toListAndSetTest =
+  all {
+      assert(Set(3, 2, 1).toList(intCompare).toSet() == Set(1, 2, 3)),
+      assert(List(2,3,1).toSet() == Set(1, 2, 3)),
+      assert(List(2,3,1).toSet() == List(3,2,1).toSet()),
+      assert(Set(2,3,1).toList(intCompare) == Set(3,1,2).toList(intCompare)),
+      assert(toList(Set(), intCompare) == List()),
+      assert(toSet(List()) == Set())
+  }
+}


### PR DESCRIPTION
This patch introduces Quint specifications that model Emerald's behavior wrt. Malachite consensus inputs. These specs is based on the `app.rs` message handlers and will be used for MBT later.