### PR TITLE
test(mbt): Expose siging provider for testing

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod app;
 mod metrics;
 pub mod node;
-mod state;
+pub mod state;
 mod store;
 mod streaming;
 mod sync_handler;

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -78,7 +78,7 @@ const CHUNK_SIZE: usize = 128 * 1024; // 128 KiB
 pub struct State {
     #[allow(dead_code)]
     ctx: EmeraldContext,
-    signing_provider: K256Provider,
+    pub signing_provider: K256Provider,
     address: Address,
     pub store: Store,
     stream_nonce: u32,


### PR DESCRIPTION
This patch exposes Emerald's signing provider so that we can use it to mock signed messages later during MBT tests.