### PR TITLE
test(mbt): Extract application runtime components

### DIFF
--- a/app/src/node.rs
+++ b/app/src/node.rs
@@ -15,6 +15,7 @@ use malachitebft_app_channel::app::node::{
     CanGeneratePrivateKey, CanMakeGenesis, CanMakePrivateKeyFile, EngineHandle, Node, NodeHandle,
 };
 use malachitebft_app_channel::app::types::core::VotingPower;
+use malachitebft_app_channel::Channels;
 use malachitebft_eth_cli::config::{Config, EmeraldConfig};
 use malachitebft_eth_cli::metrics;
 use malachitebft_eth_engine::engine::Engine;
@@ -44,7 +45,129 @@ pub struct App {
     pub start_height: Option<Height>,
 }
 
+/// Components needed to run the application
+pub struct AppRuntime {
+    pub state: State,
+    pub channels: Channels<EmeraldContext>,
+    pub engine: Engine,
+    pub emerald_config: EmeraldConfig,
+    pub engine_handle: EngineHandle,
+    pub tx_event: TxEvent<EmeraldContext>,
+}
+
 impl App {
+    /// Build the application state and all necessary components.
+    ///
+    /// This function performs all the initialization and setup required to run
+    /// the application, including loading configuration, initializing the
+    /// consensus engine, and creating the state.
+    ///
+    /// Returns a [AppRuntime] struct containing the state and all components
+    /// needed to run the app.
+    pub async fn build_runtime(&self) -> eyre::Result<AppRuntime> {
+        let config = self.load_config()?;
+        let span = tracing::error_span!("node", moniker = %config.moniker);
+        let _enter = span.enter();
+
+        let private_key_file = self.load_private_key_file()?;
+        let private_key = self.load_private_key(private_key_file);
+        let public_key = self.get_public_key(&private_key);
+        let address = self.get_address(&public_key);
+        let signing_provider = self.get_signing_provider(private_key);
+        let ctx = EmeraldContext::new();
+
+        let genesis = self.load_genesis()?;
+        let initial_validator_set = genesis.validator_set.clone();
+
+        let codec = ProtobufCodec;
+
+        let (channels, engine_handle) = malachitebft_app_channel::start_engine(
+            ctx,
+            self.clone(),
+            config.clone(),
+            codec, // WAL codec
+            codec, // Network codec
+            self.start_height,
+            initial_validator_set,
+        )
+        .await?;
+
+        let tx_event = channels.events.clone();
+
+        let registry = SharedRegistry::global().with_moniker(&config.moniker);
+        let metrics = Metrics::register(&registry);
+
+        if config.metrics.enabled {
+            tokio::spawn(metrics::serve(config.metrics.listen_addr));
+        }
+
+        let store = Store::open(self.get_home_dir().join("store.db"), metrics.db.clone()).await?;
+        let start_height = self.start_height.unwrap_or_default();
+
+        // Load cumulative metrics from database for crash recovery
+        let (txs_count, chain_bytes, elapsed_seconds) =
+            store.load_cumulative_metrics().await?.unwrap_or_else(|| {
+                tracing::info!("📊 No metrics found in database, starting with default values");
+                (0, 0, 0)
+            });
+
+        let state_metrics = StateMetrics {
+            txs_count,
+            chain_bytes,
+            elapsed_seconds,
+            metrics,
+        };
+
+        let emerald_config = self.load_emerald_config()?;
+
+        let engine: Engine = {
+            let engine_url = Url::parse(&emerald_config.engine_authrpc_address)?;
+            let jwt_path = PathBuf::from_str(&emerald_config.jwt_token_path)?;
+            let eth_url = Url::parse(&emerald_config.execution_authrpc_address)?;
+            Engine::new(
+                EngineRPC::new(engine_url, jwt_path.as_path())?,
+                EthereumRPC::new(eth_url)?,
+            )
+        };
+
+        let min_block_time = emerald_config.min_block_time;
+        let max_retain_blocks = emerald_config.max_retain_blocks;
+        let prune_at_block_interval = emerald_config.prune_at_block_interval;
+
+        assert!(
+            prune_at_block_interval != 0,
+            "prune block interval cannot be 0"
+        );
+
+        let eth_genesis_path = PathBuf::from_str(&emerald_config.eth_genesis_path)?;
+        let eth_genesis: EvmGenesis = serde_json::from_str(&fs::read_to_string(eth_genesis_path)?)?;
+
+        let evm_chain_config = eth_genesis.config;
+
+        let state = State::new(
+            genesis,
+            ctx,
+            signing_provider,
+            address,
+            start_height,
+            store,
+            state_metrics,
+            max_retain_blocks,
+            prune_at_block_interval,
+            min_block_time,
+            evm_chain_config,
+        );
+
+        Ok(AppRuntime {
+            state,
+            channels,
+            engine,
+            emerald_config,
+            engine_handle,
+            tx_event,
+        })
+    }
+
     fn load_emerald_config(&self) -> eyre::Result<EmeraldConfig> {
         let emerald_config_content =
             fs::read_to_string(&self.emerald_config_file).map_err(|e| {
@@ -132,98 +255,14 @@ impl Node for App {
     }
 
     async fn start(&self) -> eyre::Result<Handle> {
-        let config = self.load_config()?;
-        let span = tracing::error_span!("node", moniker = %config.moniker);
-        let _enter = span.enter();
-
-        let private_key_file = self.load_private_key_file()?;
-        let private_key = self.load_private_key(private_key_file);
-        let public_key = self.get_public_key(&private_key);
-        let address = self.get_address(&public_key);
-        let signing_provider = self.get_signing_provider(private_key);
-        let ctx = EmeraldContext::new();
-
-        let genesis = self.load_genesis()?;
-        let initial_validator_set = genesis.validator_set.clone();
-
-        let codec = ProtobufCodec;
-
-        let (mut channels, engine_handle) = malachitebft_app_channel::start_engine(
-            ctx,
-            self.clone(),
-            config.clone(),
-            codec, // WAL codec
-            codec, // Network codec
-            self.start_height,
-            initial_validator_set,
-        )
-        .await?;
-
-        let tx_event = channels.events.clone();
-
-        let registry = SharedRegistry::global().with_moniker(&config.moniker);
-        let metrics = Metrics::register(&registry);
-
-        if config.metrics.enabled {
-            tokio::spawn(metrics::serve(config.metrics.listen_addr));
-        }
-
-        let store = Store::open(self.get_home_dir().join("store.db"), metrics.db.clone()).await?;
-        let start_height = self.start_height.unwrap_or_default();
-
-        // Load cumulative metrics from database for crash recovery
-        let (txs_count, chain_bytes, elapsed_seconds) =
-            store.load_cumulative_metrics().await?.unwrap_or_else(|| {
-                tracing::info!("📊 No metrics found in database, starting with default values");
-                (0, 0, 0)
-            });
-
-        let state_metrics = StateMetrics {
-            txs_count,
-            chain_bytes,
-            elapsed_seconds,
-            metrics,
-        };
-
-        let emerald_config = self.load_emerald_config()?;
-
-        let engine: Engine = {
-            let engine_url = Url::parse(&emerald_config.engine_authrpc_address)?;
-            let jwt_path = PathBuf::from_str(&emerald_config.jwt_token_path)?;
-            let eth_url = Url::parse(&emerald_config.execution_authrpc_address)?;
-            Engine::new(
-                EngineRPC::new(engine_url, jwt_path.as_path())?,
-                EthereumRPC::new(eth_url)?,
-            )
-        };
-
-        let min_block_time = emerald_config.min_block_time;
-        let max_retain_blocks = emerald_config.max_retain_blocks;
-        let prune_at_block_interval = emerald_config.prune_at_block_interval;
-
-        assert!(
-            prune_at_block_interval != 0,
-            "prune block interval cannot be 0"
-        );
-
-        let eth_genesis_path = PathBuf::from_str(&emerald_config.eth_genesis_path)?;
-        let eth_genesis: EvmGenesis = serde_json::from_str(&fs::read_to_string(eth_genesis_path)?)?;
-
-        let evm_chain_config = eth_genesis.config;
-
-        let mut state = State::new(
-            genesis,
-            ctx,
-            signing_provider,
-            address,
-            start_height,
-            store,
-            state_metrics,
-            max_retain_blocks,
-            prune_at_block_interval,
-            min_block_time,
-            evm_chain_config,
-        );
+        let AppRuntime {
+            mut state,
+            mut channels,
+            engine,
+            emerald_config,
+            engine_handle,
+            tx_event,
+        } = self.build_runtime().await?;
 
         let app_handle = tokio::spawn(async move {
             if let Err(e) = crate::app::run(&mut state, &mut channels, engine, emerald_config).await


### PR DESCRIPTION
This patch extracts Emerald's runtime components to outside of the node implementation so that we can instantiate one or more Emerald applications later in the MBT environment.