### PR TITLE
test(mbt): Refactor testnet tasks for reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release test docs docs-serve testnet-start sync testnet-node-stop testnet-node-restart testnet-stop testnet-clean clean-volumes clean-prometheus spam spam-contract
+.PHONY: all build release test docs docs-serve testnet-config testnet-reth-recreate testnet-reth-restart testnet-start sync testnet-node-stop testnet-node-restart testnet-stop testnet-clean clean-volumes clean-prometheus spam spam-contract
 
 all: build
 
@@ -25,27 +25,33 @@ docs-serve:
 
 # Testnet (local deployment)
 
-testnet-start: testnet-clean build
-	./scripts/generate_testnet_config.sh --nodes 4 --testnet-config-dir .testnet
-	cargo run --bin emerald -- testnet --home nodes --testnet-config .testnet/testnet_config.toml
-	ls nodes/*/config/priv_validator_key.json | xargs -I{} cargo run --bin emerald show-pubkey {} > nodes/validator_public_keys.txt
-	cargo run --bin emerald-utils genesis --public-keys-file ./nodes/validator_public_keys.txt --devnet
-	docker compose up -d reth0 reth1 reth2 reth3 prometheus grafana otterscan
-	./scripts/add_peers.sh --nodes 4
-	@echo 👉 Grafana dashboard is available at http://localhost:4000
-	bash scripts/spawn.bash --nodes 4 --home nodes --no-delay
+RETH_NODES ?= reth0 reth1 reth2 reth3
 
-sync: testnet-clean build
-	./scripts/generate_testnet_config.sh --nodes 4 --testnet-config-dir .testnet
+testnet-config: testnet-clean build
+	./scripts/generate_testnet_config.sh --nodes $(words $(RETH_NODES)) --testnet-config-dir .testnet
 	cargo run --bin emerald -- testnet --home nodes --testnet-config .testnet/testnet_config.toml
 	ls nodes/*/config/priv_validator_key.json | xargs -I{} cargo run --bin emerald show-pubkey {} > nodes/validator_public_keys.txt
 	cargo run --bin emerald-utils genesis --public-keys-file ./nodes/validator_public_keys.txt --devnet
-	docker compose up -d
-	./scripts/add_peers.sh --nodes 4
+
+testnet-reth-recreate:
+	docker compose down -v $(RETH_NODES)
+	docker compose up -d $(RETH_NODES)
+	./scripts/add_peers.sh --nodes $(words $(RETH_NODES))
+
+testnet-reth-restart:
+	docker compose restart $(RETH_NODES)
+
+testnet-start: testnet-config testnet-reth-recreate
+	docker compose up -d prometheus grafana otterscan
+	@echo 👉 Grafana dashboard is available at http://localhost:4000
+	bash scripts/spawn.bash --nodes $(words $(RETH_NODES)) --home nodes --no-delay
+
+sync: testnet-config testnet-reth-recreate
+	docker compose up -d prometheus grafana otterscan
 	@echo 👉 Grafana dashboard is available at http://localhost:4000
 	cp monitoring/prometheus-syncing.yml monitoring/prometheus.yml
 	docker compose restart prometheus
-	bash scripts/spawn.bash --nodes 4 --home nodes
+	bash scripts/spawn.bash --nodes $(words $(RETH_NODES)) --home nodes
 
 NODE ?= 0# default node 0
 
@@ -65,6 +71,7 @@ testnet-stop:
 testnet-clean: clean-prometheus clean-volumes
 	rm -rf ./.testnet
 	rm -rf ./assets/genesis.json
+	rm -rf ./assets/emerald_genesis.json
 	rm -rf ./nodes
 	rm -rf ./monitoring/data-grafana
 

--- a/scripts/add_peers.sh
+++ b/scripts/add_peers.sh
@@ -84,7 +84,7 @@ for ((i = 0; i < NODES_COUNT; i++)); do
 
     echo "Waiting for Reth node $i on ${NODE_IP}:${PORT} to be ready..."
     until cast rpc --rpc-url "${NODE_IP}:${PORT}" net_listening > /dev/null 2>&1; do
-        sleep 1
+        sleep .1 # 100ms
     done
 
     ENODE=$(cast rpc --rpc-url "${NODE_IP}:${PORT}" admin_nodeInfo | jq -r .enode)

--- a/scripts/generate_testnet_config.sh
+++ b/scripts/generate_testnet_config.sh
@@ -27,6 +27,8 @@ EOF
     exit 2
 }
 
+ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../" &> /dev/null && pwd )
+
 nodes=""
 testnet_config_dir=""
 node_keys=()
@@ -238,11 +240,11 @@ for ((i = 0; i < nodes; i++)); do
 moniker = "test-$i"
 execution_authrpc_address = "http://$NODE_IP:$ENGINE_PORT"
 engine_authrpc_address = "http://$NODE_IP:$AUTH_PORT"
-jwt_token_path = "./assets/jwtsecret"
+jwt_token_path = "$ROOT_DIR/assets/jwtsecret"
 retry_config.initial_delay = "100ms"
 retry_config.max_delay = "2s"
 retry_config.max_elapsed_time = "20s"
-eth_genesis_path="./assets/genesis.json"
+eth_genesis_path="$ROOT_DIR/assets/genesis.json"
 EOF
  # Set max_retain_blocks for pruning nodes
       if [[ ${#PRUNING_NODES[@]} -gt 0 && " ${PRUNING_NODES[@]} " =~ " ${i} " ]]; then


### PR DESCRIPTION
This patch refactors some of the Makefile tasks and testnet scripts so that they can be reused when setting up the MBT test environment later. The MBT setup will call `make testnet-reth-recreate` and `make testnet-reth-restart` to setup the test environment and or simulate node failures.