### PR TITLE
fix(app): set next height on consensus_ready

### DIFF
--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -43,7 +43,7 @@ pub async fn initialize_state_from_genesis(state: &mut State, engine: &Engine) -
         read_validators_from_contract(engine.eth.url().as_ref(), &genesis_block.block_hash).await?;
     debug!("🌈 Got genesis validator set: {:?}", genesis_validator_set);
     state.current_height = Height::new(genesis_block.block_number);
-    state.set_validator_set(state.current_height, genesis_validator_set);
+    state.set_validator_set(state.current_height.increment(), genesis_validator_set);
     Ok(())
 }
 


### PR DESCRIPTION
On receiving ConsensusReady from the consensus engine, Emerald sets the current height either to the height of the genesis block (retrieved from the EL) or the height of the latest decided height (retrieved from the local store). Then, it informs the consensus engine to start at the next height, i.e., current height + 1.  