### PR TITLE
test(mbt): Ensure reth recreate and restart wait for reth containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,11 @@ testnet-config: testnet-clean build
 testnet-reth-recreate:
 	docker compose down -v $(RETH_NODES)
 	docker compose up -d $(RETH_NODES)
-	./scripts/add_peers.sh --nodes $(words $(RETH_NODES))
+	./scripts/add_peers.sh --nodes $$(docker compose ps --status running --format "{{.Name}}" | grep -c reth)
 
 testnet-reth-restart:
 	docker compose restart $(RETH_NODES)
+	./scripts/add_peers.sh --nodes $$(docker compose ps --status running --format "{{.Name}}" | grep -c reth)
 
 testnet-start: testnet-config testnet-reth-recreate
 	docker compose up -d prometheus grafana otterscan


### PR DESCRIPTION
At some point the add_peers.sh script was less dynamic and would wait for all reth nodes. The script has been refactored and not it requires the proper count of nodes in the reth network to wait and connect them.

This patch makes sure that during testnet and later MBT simulations we always wait and connect the correct amount of reth nodes in the environment based on how many reth containers are running at the moment.