### PR TITLE
test(mbt): Add Model Based Test for Emerald

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 # If new code is pushed to a PR branch, then cancel in progress workflows for that PR.
 # Ensures that we don't waste CI time, and returns results quicker.
@@ -20,7 +21,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_DEV_DEBUG: 1
   CARGO_PROFILE_RELEASE_DEBUG: 1
-  RUST_BACKTRACE: short
+  RUST_BACKTRACE: full
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
 
@@ -60,5 +61,54 @@ jobs:
             --workspace \
             --all-features \
             --no-fail-fast \
-            --failure-output final
+            --failure-output final \
+            --filterset 'not package(emerald-mbt)'
+        if: steps.filter.outputs.code == 'true'
+
+  mbt:
+    name: MBT Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # XXX: Do not block on MBT initially until we gain confidence CI is not
+    # flaky for any reason.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.rs'
+              - '**/*.qnt'
+              - 'Makefile'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '**/*.sh'
+              - '*/workflows/test.yml'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install Quint
+        run: bun install -g @informalsystems/quint
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Run MBT suite
+        run: make mbt-test
         if: steps.filter.outputs.code == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2282,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu-base"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
+
+[[package]]
+name = "dashu-int"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,6 +2639,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "emerald-mbt"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "bimap",
+ "emerald",
+ "informalsystems-malachitebft-app-channel",
+ "informalsystems-malachitebft-core-consensus",
+ "itf 0.2.4",
+ "malachitebft-eth-cli",
+ "malachitebft-eth-engine",
+ "malachitebft-eth-types",
+ "quint-connect",
+ "serde",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "emerald-utils"
 version = "0.0.1"
 dependencies = [
@@ -2718,7 +2773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3499,7 +3554,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration 0.7.0",
  "tokio",
  "tower-layer",
@@ -4130,6 +4185,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itf"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1bbb9bbb46408c303da511b75b446e9c5ef3d74bf0f7028cfeb0f811a2c24d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "itf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d620b7b3d17650581da9208d1240baaff4ee33decff1c7782bdb9b4cab71c20"
+dependencies = [
+ "dashu-int",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -5194,7 +5274,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5219,6 +5299,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5254,6 +5335,21 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
 ]
 
 [[package]]
@@ -6132,7 +6228,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6169,9 +6265,38 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quint-connect"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a66d8666ae428df917037dc064921a48ac74ff5758033aa388c1cd3e24af551"
+dependencies = [
+ "anyhow",
+ "colored",
+ "itf 0.4.0",
+ "quint-connect-macros",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "similar",
+ "tempfile",
+ "version_check",
+]
+
+[[package]]
+name = "quint-connect-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfca0f8a49678da6e1a671b5aab8e284a8b548096e6921c0640986a7b451eaff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7372,7 +7497,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7893,6 +8018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8159,7 +8290,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9039,7 +9170,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,15 @@ members = [
   "engine",
   "utils",
   "types",
+  "tests/mbt",
+]
+
+default-members = [
+  "app",
+  "cli",
+  "engine",
+  "utils",
+  "types",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release test docs docs-serve testnet-config testnet-reth-recreate testnet-reth-restart testnet-start sync testnet-node-stop testnet-node-restart testnet-stop testnet-clean clean-volumes clean-prometheus spam spam-contract
+.PHONY: all build release test docs docs-serve testnet-config testnet-reth-recreate testnet-reth-restart testnet-start sync testnet-node-stop testnet-node-restart testnet-stop testnet-clean clean-volumes clean-prometheus spam spam-contract mbt-test mbt-clean
 
 all: build
 
@@ -105,3 +105,15 @@ spam-contract:
 		--time=60 \
 		--rate=1000 \
 		--rpc-url=127.0.0.1:8645
+
+# Model-Based Testing (MBT)
+
+TEST ?=
+
+mbt-test: RETH_NODES=reth0 reth1 reth2
+mbt-test: testnet-config
+	@echo "Running MBT tests..."
+	@echo "Note: RETH will be automatically started and stopped for each test"
+	cargo test --package emerald-mbt -- --nocapture --test-threads=1 $(TEST)
+
+mbt-clean: testnet-clean

--- a/tests/mbt/Cargo.toml
+++ b/tests/mbt/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name    = "emerald-mbt"
+version = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+emerald                     = { workspace = true }
+malachitebft-eth-types      = { workspace = true }
+malachitebft-eth-engine     = { workspace = true }
+malachitebft-eth-cli        = { workspace = true }
+malachitebft-app-channel    = { workspace = true }
+malachitebft-core-consensus = { workspace = true }
+
+serde = { workspace = true }
+itf   = { workspace = true }
+tokio = { workspace = true }
+
+quint-connect = "0.1"
+anyhow        = "1.0"
+bimap         = "0.6.3"
+tempfile      = "3.23.0"

--- a/tests/mbt/src/driver.rs
+++ b/tests/mbt/src/driver.rs
@@ -1,0 +1,83 @@
+mod environment;
+mod utils;
+
+use std::collections::BTreeMap;
+
+use quint_connect::{switch, Result, Step};
+
+use crate::history::History;
+use crate::runtime::Runtime;
+use crate::state::{Node, SpecState};
+use crate::sut::{self, Sut};
+
+/// Model-based testing driver for Emerald.
+///
+/// Connects a Quint formal specification to the Emerald implementation,
+/// executing actions taken on the system under test (SUT) while tracking
+/// execution history for verification.
+#[derive(Default)]
+pub struct EmeraldDriver {
+    pub sut: BTreeMap<Node, Sut>,
+    pub history: History,
+    pub runtime: Option<Runtime>,
+}
+
+impl quint_connect::Driver for EmeraldDriver {
+    type State = SpecState;
+
+    fn config() -> quint_connect::Config {
+        quint_connect::Config {
+            state: &["emerald::choreo::s", "system"],
+            nondet: &["emerald::choreo::s", "extensions", "action_taken"],
+        }
+    }
+
+    /// Called for each action taken in the Quint trace. It maps the Quint
+    /// action and its associated values with the equivalent code in the SUT.
+    fn step(&mut self, step: &Step) -> Result {
+        switch!(step {
+            InitAction => {
+                self.set_initial_state()?;
+            },
+            ConsensusReadyAction(node) => {
+                self.perform(node, |app, _|
+                    app.consensus_ready()
+                )?;
+            },
+            StartedRoundAction(node, height, round, proposer) => {
+                self.perform(node, |app, hist|
+                    app.started_round(hist, height, round, proposer)
+                )?;
+            },
+            GetValueAction(node, height, round, proposal) => {
+                self.perform(node, |app, hist|
+                    app.get_value(hist, height, round, proposal)
+                )?;
+            },
+            ReceivedProposalAction(node, proposal) => {
+                self.perform(node, |app, hist|
+                    app.receive_proposal(hist, proposal)
+                )?;
+            },
+            ProcessSyncedValueAction(node, proposal) => {
+                self.perform(node, |app, hist|
+                    app.process_synced_value(hist, proposal)
+                )?;
+            },
+            DecidedAction(node, proposal) => {
+                let votes = sut::mock_votes(&self.sut, &self.history, &proposal)?;
+                self.perform(node, |app, hist|
+                    app.decided(hist, proposal, votes)
+                )?;
+            },
+            GetDecidedValueAction(node, height, proposal?) => {
+                self.perform(node, |app, hist|
+                    app.get_decided(hist, height, proposal)
+                )?;
+            },
+            Failure(node, mode) => {
+                self.failure(node, mode)?;
+            }
+        })
+    }
+}

--- a/tests/mbt/src/driver/environment.rs
+++ b/tests/mbt/src/driver/environment.rs
@@ -1,0 +1,167 @@
+use core::time::Duration;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use emerald::node::{App as EmeraldApp, AppRuntime};
+use malachitebft_eth_cli::config;
+use malachitebft_eth_types::{Address, Height as EmeraldHeight};
+use tempfile::TempDir;
+
+use crate::driver::EmeraldDriver;
+use crate::runtime::Runtime;
+use crate::state::{FailureMode, Node};
+use crate::sut::Sut;
+use crate::{reth, NODES};
+
+impl EmeraldDriver {
+    /// (Re)initializes the test environment by resetting the driver its initial
+    /// state and creating one Emerald and Reth instance per [crate::NODES].
+    pub fn set_initial_state(&mut self) -> Result<()> {
+        // Reset the driver
+        *self = Self::default();
+        reth::recreate_all()?;
+
+        // Fresh test directory for the new environment
+        let test_dir = TempDir::with_prefix("emerald-mbt")?;
+
+        for (node_idx, node) in NODES.iter().enumerate() {
+            let node = node.to_string();
+            let home_dir = TempDir::with_suffix_in(&node, &test_dir)?;
+            self.init_node(node_idx, node, home_dir)?;
+        }
+
+        self.runtime.replace(Runtime::new(test_dir)?);
+        Ok(())
+    }
+
+    /// Simulates a failure on the given node according to the failure mode:
+    ///
+    /// - [FailureMode::ConsensusTimeout]: No-op, model provides next inputs
+    /// - [FailureMode::NodeCrash]: Recreates Reth and Emerald
+    /// - [FailureMode::NodeRestart]: Restarts Reth and Emerald
+    /// - [FailureMode::ProcessRestart]: Restarts Emerald only
+    pub fn failure(&mut self, node: Node, mode: FailureMode) -> Result<()> {
+        if let FailureMode::ConsensusTimeout = mode {
+            // Noop wrt. MBT. The model will follow up with the proper consensus
+            // input later.
+            return Ok(());
+        }
+
+        let node_idx = NODES
+            .iter()
+            .position(|&other| node == other)
+            .ok_or(anyhow!("Unknown node: {node}"))?;
+
+        let home_dir = match mode {
+            // Both Emerald and Reth crashed and lost their data. Recreate Reth
+            // and return a new empty home dir for Emerald to start from.
+            FailureMode::NodeCrash => {
+                self.stop_node(&node)?;
+                reth::recreate(node_idx)?;
+                TempDir::with_suffix_in(
+                    &node,
+                    self.runtime
+                        .as_ref()
+                        .map(|rt| rt.temp_dir.path())
+                        .ok_or(anyhow!("Uninitialized test dir"))?,
+                )?
+            }
+            // Both Emerald and Reth restarted without data loss. Restart
+            // Emerald and return the previous home dir for Emerald to start
+            // from.
+            FailureMode::NodeRestart => {
+                let home_dir = self.stop_node(&node)?;
+                reth::restart(node_idx)?;
+                home_dir
+            }
+            // Just Emerald restarted without data loss. Return the previous
+            // home dir for Emerald to start form.
+            FailureMode::ProcessRestart => self.stop_node(&node)?,
+            FailureMode::ConsensusTimeout => unreachable!(),
+        };
+
+        self.init_node(node_idx, node, home_dir)?;
+        Ok(())
+    }
+
+    fn init_node(&mut self, node_idx: usize, node: String, home_dir: TempDir) -> Result<()> {
+        let home_path = home_dir.path().to_path_buf();
+        let runtime = Runtime::new(home_dir)?;
+        let components = runtime.block_on(self.init_app_state(node_idx, home_path))?;
+
+        let public_key = components.state.signing_provider.private_key().public_key();
+        let address = Address::from_public_key(&public_key);
+        self.history.record_address(node.clone(), address);
+
+        self.sut.insert(
+            node,
+            Sut {
+                components,
+                address,
+                runtime,
+            },
+        );
+
+        Ok(())
+    }
+
+    async fn init_app_state(&mut self, node_idx: usize, home_dir: PathBuf) -> Result<AppRuntime> {
+        let mut app = Self::setup_app(node_idx, home_dir)?;
+
+        // Disable unecessary components since Malachite is being mocked for MBT.
+        app.config.consensus.enabled = false;
+        app.config.value_sync.enabled = false;
+        app.config.metrics.enabled = false;
+
+        app.build_runtime()
+            .await
+            .map_err(|err| anyhow!("Failed to build app state: {err:?}"))
+    }
+
+    fn setup_app(node_idx: usize, home_dir: PathBuf) -> Result<EmeraldApp> {
+        let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()?;
+
+        let emerald_config_file = project_root
+            .join(".testnet/config")
+            .join(node_idx.to_string())
+            .join("config.toml");
+
+        let nodes_path = project_root.join("nodes").join(node_idx.to_string());
+        let config_file = nodes_path.join("config/config.toml");
+        let genesis_file = nodes_path.join("config/genesis.json");
+        let private_key_file = nodes_path.join("config/priv_validator_key.json");
+
+        let config = config::load_config(&config_file, None)
+            .map_err(|err| anyhow!("Failed to load config file: {err}"))?;
+
+        Ok(EmeraldApp {
+            config,
+            home_dir,
+            genesis_file,
+            emerald_config_file,
+            private_key_file,
+            start_height: Some(EmeraldHeight::new(0)),
+        })
+    }
+
+    fn stop_node(&mut self, node: &Node) -> Result<TempDir> {
+        // NOTE: by removing the SUT from the driver state we let its components
+        // drop and clean up. We only return the node's `temp_dir` so that the
+        // caller can decide to reuse it or not.
+        let sut = self
+            .sut
+            .remove(node)
+            .ok_or(anyhow!("No SUT for node: {node}"))?;
+
+        let Runtime { temp_dir, tokio } = sut.runtime;
+
+        // NOTE: we attempt to wait for its tasks to get completed before
+        // returning the `temp_dir` so that no advisory locks (libc's flock) are
+        // held on Malachite's WAL.
+        tokio.shutdown_timeout(Duration::from_secs(5));
+
+        Ok(temp_dir)
+    }
+}

--- a/tests/mbt/src/driver/utils.rs
+++ b/tests/mbt/src/driver/utils.rs
@@ -1,0 +1,26 @@
+use core::future::Future;
+
+use anyhow::{bail, Result};
+
+use crate::driver::EmeraldDriver;
+use crate::history::History;
+use crate::state::Node;
+use crate::sut::Sut;
+
+impl EmeraldDriver {
+    /// Locates the system under test and use the driver's runtime to wait for
+    /// the execution of the given future.
+    pub fn perform<'a, F, Fut>(&'a mut self, node: Node, action: F) -> Result<()>
+    where
+        F: FnOnce(&'a mut Sut, &'a mut History) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let Some(sut) = self.sut.get_mut(&node) else {
+            bail!("Unknown node: {node}")
+        };
+        let Some(rt) = &mut self.runtime else {
+            bail!("Runtime is uninitialized")
+        };
+        rt.block_on(action(sut, &mut self.history))
+    }
+}

--- a/tests/mbt/src/history.rs
+++ b/tests/mbt/src/history.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, Result};
+use bimap::BiMap;
+use malachitebft_app_channel::app::streaming::StreamMessage;
+use malachitebft_app_channel::app::types::core::Round as EmeraldRound;
+use malachitebft_eth_engine::json_structures::ExecutionBlock;
+use malachitebft_eth_types::{
+    Address, BlockHash, Height as EmeraldHeight, ProposalPart, Value, ValueId as EmeraldValueId,
+};
+
+use crate::state::{Node, Payload, Proposal, ValueId};
+
+/// Records mappings between Quint and Emerald state.
+///
+/// Historical data is used when referring to values produced by Emerald during
+/// an earlier step. For example, when Quint produces a GetValue step, replaying
+/// it in Emerald generates a stream of message parts. Later, Quint may include a
+/// ReceivedProposal step in the trace, which requires the driver to feed
+/// message parts of a given proposal to the target node. It ends up being
+/// simpler to remember the message parts from earlier than to produce them
+/// again later.
+#[derive(Default)]
+pub struct History {
+    pub addresses: BiMap<Node, Address>,
+    pub proposals: BiMap<Proposal, (EmeraldHeight, EmeraldRound, EmeraldValueId)>,
+    pub streams: BTreeMap<ValueId, Vec<StreamMessage<ProposalPart>>>,
+    pub values: BTreeMap<ValueId, Value>,
+    pub blocks: BiMap<Payload, BlockHash>,
+}
+
+impl History {
+    /// Returns the Emerald address for a given Quint node.
+    pub fn get_address(&self, node: &Node) -> Result<Address> {
+        self.addresses
+            .get_by_left(node)
+            .cloned()
+            .ok_or(anyhow!("Can't find address for node: {node}"))
+    }
+
+    /// Returns the payload for a given block hash.
+    pub fn get_payload(&self, hash: &BlockHash) -> Result<Payload> {
+        self.blocks
+            .get_by_right(hash)
+            .cloned()
+            .ok_or(anyhow!("Can't find payload for hash: {hash}"))
+    }
+
+    /// Returns the Quint proposal for a given Emerald value.
+    pub fn get_proposal(
+        &self,
+        height: EmeraldHeight,
+        round: EmeraldRound,
+        value_id: EmeraldValueId,
+    ) -> Result<Proposal> {
+        self.proposals
+            .get_by_right(&(height, round, value_id))
+            .cloned()
+            .ok_or(anyhow!("No proposal for value id: {value_id}"))
+    }
+
+    /// Returns the stream message parts for a given Quint value.
+    pub fn get_stream(&self, value_id: &ValueId) -> Result<Vec<StreamMessage<ProposalPart>>> {
+        self.streams
+            .get(value_id)
+            .cloned()
+            .ok_or(anyhow!("No stream parts for value id: {value_id:?}"))
+    }
+
+    /// Returns the Emerald value for a given Quint value.
+    pub fn get_value(&self, value_id: &ValueId) -> Result<Value> {
+        self.values
+            .get(value_id)
+            .cloned()
+            .ok_or(anyhow!("No value for id: {value_id:?}"))
+    }
+
+    /// Returns the Emerald value ID for a given Quint proposal.
+    pub fn get_value_id(&self, proposal: &Proposal) -> Result<EmeraldValueId> {
+        let (_, _, value_id) = self
+            .proposals
+            .get_by_left(proposal)
+            .cloned()
+            .ok_or(anyhow!("No value id for proposal: {proposal:?}"))?;
+        Ok(value_id)
+    }
+
+    /// Records the mapping between a Quint node and its Emerald address.
+    pub fn record_address(&mut self, node: Node, address: Address) {
+        self.addresses.insert(node, address);
+    }
+
+    /// Records a Quint proposal along with its Emerald value and message parts.
+    pub fn record_proposal(
+        &mut self,
+        proposal: Proposal,
+        value: Value,
+        stream: Vec<StreamMessage<ProposalPart>>,
+    ) {
+        let height = EmeraldHeight::new(proposal.height);
+        let round = EmeraldRound::new(proposal.round);
+        let value_id = value.id();
+
+        self.values.insert(proposal.id(), value);
+        self.streams.insert(proposal.id(), stream);
+        self.proposals.insert(proposal, (height, round, value_id));
+    }
+
+    /// Records the mapping between a Quint proposal's payload and the Emerald
+    /// execution block hash.
+    pub fn record_block(&mut self, proposal: Proposal, block: ExecutionBlock) {
+        self.blocks.insert(proposal.payload, block.block_hash);
+    }
+}

--- a/tests/mbt/src/lib.rs
+++ b/tests/mbt/src/lib.rs
@@ -1,0 +1,12 @@
+mod driver;
+mod history;
+mod reth;
+mod runtime;
+mod state;
+mod sut;
+
+pub use driver::EmeraldDriver;
+
+// Node identifiers. They must match the `emerald_mbt.qnt` and
+// `emerald_tests.qnt` specifications.
+const NODES: [&str; 3] = ["node1", "node2", "node3"];

--- a/tests/mbt/src/reth.rs
+++ b/tests/mbt/src/reth.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{ensure, Result};
+
+use crate::NODES;
+
+/// Recreate all Reth instances using the project's testnet commands.
+///
+/// Note that reth instance names are composed based on the [NODES] list. If
+/// there are 3 nodes in [NODES], Reth instances will be `reth0 reth1 reth2`,
+/// for example.
+pub fn recreate_all() -> Result<()> {
+    let mut nodes = String::new();
+    for i in 0..NODES.len() {
+        nodes.push_str("reth");
+        nodes.push_str(&i.to_string());
+        nodes.push(' ');
+    }
+    run_reth_make_cmd(&nodes, "testnet-reth-recreate")
+}
+
+/// Recreate the given Reth instance using the project's testnet commands.
+///
+/// The given node index becomes the Reth identifier in the testnet config. If 0
+/// is given, the `reth0` instance will be recreated, for example.
+pub fn recreate(node_idx: usize) -> Result<()> {
+    run_reth_make_cmd(&format!("reth{node_idx}"), "testnet-reth-recreate")
+}
+
+/// Restart the given Reth instance using the project's testnet commands.
+///
+/// The given node index becomes the Reth identifier in the testnet config. If 0
+/// is given, the `reth0` instance will be restarted, for example.
+pub fn restart(node_idx: usize) -> Result<()> {
+    run_reth_make_cmd(&format!("reth{node_idx}"), "testnet-reth-restart")
+}
+
+fn run_reth_make_cmd(nodes: &str, cmd: &str) -> Result<()> {
+    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()?;
+
+    let res = Command::new("make")
+        .env("RETH_NODES", nodes)
+        .arg(cmd)
+        .current_dir(project_root)
+        .output()?;
+
+    ensure!(
+        res.status.success(),
+        "Failed to run make command: {}",
+        String::from_utf8_lossy(&res.stderr),
+    );
+
+    Ok(())
+}

--- a/tests/mbt/src/runtime.rs
+++ b/tests/mbt/src/runtime.rs
@@ -1,0 +1,31 @@
+use core::future::Future;
+
+use anyhow::Result;
+use tempfile::TempDir;
+use tokio::runtime::Runtime as TokioRt;
+
+/// The test execution runtime.
+///
+/// A runtime is composed of a Tokio runtime for running async tasks, and a
+/// temporary directory that is cleaned after the test is done.
+pub struct Runtime {
+    pub tokio: TokioRt,
+    pub temp_dir: TempDir,
+}
+
+impl Runtime {
+    pub fn new(temp_dir: TempDir) -> Result<Self> {
+        Ok(Self {
+            tokio: TokioRt::new()?,
+            temp_dir,
+        })
+    }
+
+    #[inline]
+    pub fn block_on<F>(&self, f: F) -> F::Output
+    where
+        F: Future,
+    {
+        self.tokio.block_on(f)
+    }
+}

--- a/tests/mbt/src/state.rs
+++ b/tests/mbt/src/state.rs
@@ -1,0 +1,151 @@
+//! This module maps Quint and Emerald states. Only relevant parts of the
+//! Emerald state are captured. Quint Connect is responsible for comparing the
+//! extracted data with the Quint state.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Context;
+use emerald::state::{assemble_value_from_parts, State};
+use itf::de::{self, As};
+use malachitebft_app_channel::app::types::core::Round as EmeraldRound;
+use malachitebft_eth_types::Height as EmeraldHeight;
+use quint_connect::Result;
+use serde::Deserialize;
+
+use crate::driver::EmeraldDriver;
+
+pub type Node = String;
+pub type Height = u64;
+pub type Round = u32;
+pub type Payload = u64;
+pub type ValueId = (Height, Round, Payload);
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, Deserialize)]
+pub struct Proposal {
+    pub height: Height,
+    pub round: Round,
+    pub proposer: Node,
+    pub payload: Payload,
+}
+
+impl Proposal {
+    pub fn id(&self) -> ValueId {
+        (self.height, self.round, self.payload)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+pub struct NodeState {
+    pub consensus_height: Height,
+    pub consensus_round: Round,
+    pub last_decided_height: Height,
+    #[serde(with = "As::<de::Option::<_>>")]
+    pub last_decided_payload: Option<Payload>,
+    pub proposals: BTreeSet<Proposal>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(tag = "tag")]
+pub enum FailureMode {
+    NodeCrash,
+    NodeRestart,
+    ProcessRestart,
+    ConsensusTimeout,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+pub struct SpecState(pub BTreeMap<Node, NodeState>);
+
+impl quint_connect::State<EmeraldDriver> for SpecState {
+    fn from_driver(driver: &EmeraldDriver) -> Result<Self> {
+        let mut system = BTreeMap::new();
+        let rt = driver.runtime.as_ref().context("Uninitialized runtime")?;
+
+        for (node, app) in &driver.sut {
+            let state = &app.components.state;
+            let proposals = rt.block_on(get_proposals(driver, state))?;
+            let (last_decided_height, last_decided_payload) = get_latest_block_info(driver, state)?;
+
+            let spec_state = NodeState {
+                consensus_height: state.consensus_height.as_u64(),
+                consensus_round: state
+                    .consensus_round
+                    .as_u32()
+                    .context("Invalid consensus round")?,
+                last_decided_height,
+                last_decided_payload,
+                proposals,
+            };
+
+            system.insert(node.clone(), spec_state);
+        }
+
+        Ok(Self(system))
+    }
+}
+
+fn get_latest_block_info(
+    driver: &EmeraldDriver,
+    state: &State,
+) -> Result<(Height, Option<Payload>)> {
+    match &state.latest_block {
+        None => Ok((0, None)),                                   // genesis
+        Some(block) if block.block_number == 0 => Ok((0, None)), // genesis
+        Some(block) => {
+            let payload = driver.history.get_payload(&block.block_hash)?;
+            Ok((block.block_number, Some(payload)))
+        }
+    }
+}
+
+async fn get_proposals(driver: &EmeraldDriver, state: &State) -> Result<BTreeSet<Proposal>> {
+    let mut proposals = BTreeSet::new();
+    let mut max_height = 1;
+    let mut max_round = 0;
+
+    for (proposal, _) in &driver.history.proposals {
+        max_height = max_height.max(proposal.height);
+        max_round = max_round.max(proposal.round);
+    }
+
+    for height in 1..=max_height {
+        let height = EmeraldHeight::new(height);
+
+        if let Some(decided) = state.store.get_decided_value(height).await? {
+            let height = decided.certificate.height;
+            let round = decided.certificate.round;
+            let value_id = decided.certificate.value_id;
+            let proposal = driver.history.get_proposal(height, round, value_id)?;
+            proposals.insert(proposal);
+        }
+
+        for round in 0..=max_round {
+            let round = EmeraldRound::new(round);
+            let undecided_proposals = state.store.get_undecided_proposals(height, round).await?;
+
+            for proposed_value in undecided_proposals {
+                let height = proposed_value.height;
+                let round = proposed_value.round;
+                let value_id = proposed_value.value.id();
+                let proposal = driver.history.get_proposal(height, round, value_id)?;
+                proposals.insert(proposal.clone());
+            }
+
+            let pending_parts = state
+                .store
+                .get_pending_proposal_parts(height, round)
+                .await?;
+
+            for parts in pending_parts {
+                let (proposed_value, _) = assemble_value_from_parts(parts);
+                let height = proposed_value.height;
+                let round = proposed_value.round;
+                let value_id = proposed_value.value.id();
+                let proposal = driver.history.get_proposal(height, round, value_id)?;
+                proposals.insert(proposal);
+            }
+        }
+    }
+
+    Ok(proposals)
+}

--- a/tests/mbt/src/sut.rs
+++ b/tests/mbt/src/sut.rs
@@ -1,0 +1,71 @@
+mod consensus_ready;
+mod decided;
+mod get_decided;
+mod get_value;
+mod process_synced_value;
+mod receive_proposal;
+mod started_round;
+
+use anyhow::{anyhow, Result};
+pub use decided::mock_votes;
+use emerald::app::process_consensus_message;
+use emerald::node::AppRuntime;
+use malachitebft_app_channel::AppMsg;
+use malachitebft_eth_types::{Address, EmeraldContext};
+use tokio::sync::oneshot::Receiver;
+
+use crate::runtime::Runtime;
+
+/// The Emerald system under test (SUT).
+///
+/// There is one instance of [Sut] per Emerald node in the Quint trace, which is
+/// composed of its address, state components, and local runtime.
+///
+/// Note that SUT implementation is split on different files at the `sut/`
+/// directory where each file focus on the translation of one Quint action.
+pub struct Sut {
+    pub address: Address,
+    pub components: AppRuntime,
+    // XXX: There is some task being spawned into the current tokio runtime
+    // during the StateComponents initialization that is leaking in the sense
+    // that dropping the StateComponents struct doesn't cancel the loop task.
+    //
+    // This comes up in the form of a held lock on Malachite's WAL that prevents
+    // us from simulating a node restart by simply dropping the struct and
+    // recreating it pointing to the same home dir.
+    //
+    // Adding a separate runtime per SUT is a workaround so that we can drop
+    // both StateComponents and its associated Runtime. Dropping the Tokio
+    // runtime also drops the loop tasks that are holding the WAL lock, hence
+    // allowing us to simulate process restarts where the same home dir is
+    // reused.
+    pub runtime: Runtime,
+}
+
+impl Sut {
+    /// Process an [AppMsg] using Emerald consensus logic.
+    ///
+    /// This is the primary Emerald entrypoint for testing. For every Quint
+    /// action that needs to be replayed into the Emerald instance, the test
+    /// code must translate the Quint step into an [AppMsg] and feed it to this
+    /// method.
+    async fn process_msg<Out>(
+        &mut self,
+        msg: AppMsg<EmeraldContext>,
+        reply: Receiver<Out>,
+    ) -> Result<Out> {
+        process_consensus_message(
+            msg,
+            &mut self.components.state,
+            &mut self.components.channels,
+            &self.components.engine,
+            &self.components.emerald_config,
+        )
+        .await
+        .map_err(|err| anyhow!("Failed to process consensus message: {err:?}"))?;
+
+        reply
+            .await
+            .map_err(|err| anyhow!("Failed waiting for application reply: {err}"))
+    }
+}

--- a/tests/mbt/src/sut/consensus_ready.rs
+++ b/tests/mbt/src/sut/consensus_ready.rs
@@ -1,0 +1,17 @@
+//! Translates ConsensusReadyAction from Quint to AppMsg::ConsensusReady.
+
+use anyhow::Result;
+use malachitebft_app_channel::AppMsg;
+
+use super::Sut;
+
+impl Sut {
+    /// Replays the ConsensusReady Quint action (see emerald.qnt
+    /// handle_consensus_ready).
+    pub async fn consensus_ready(&mut self) -> Result<()> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        let msg = AppMsg::ConsensusReady { reply: reply_tx };
+        self.process_msg(msg, reply_rx).await?;
+        Ok(())
+    }
+}

--- a/tests/mbt/src/sut/decided.rs
+++ b/tests/mbt/src/sut/decided.rs
@@ -1,0 +1,76 @@
+//! Translates DecidedAction from Quint to AppMsg::Decided.
+
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, Result};
+use malachitebft_app_channel::app::types::core::{
+    CommitCertificate, NilOrVal, Round as EmeraldRound, SignedVote,
+};
+use malachitebft_app_channel::AppMsg;
+use malachitebft_eth_types::{EmeraldContext, Height as EmeraldHeight, Vote};
+
+use super::Sut;
+use crate::history::History;
+use crate::state::{Node, Proposal};
+
+impl Sut {
+    /// Replays the Decided Quint action (see emerald.qnt handle_decided).
+    ///
+    /// Note that the caller must call [mock_votes] to generate a set of mocked
+    /// votes prior to calling this method.
+    ///
+    /// This method relies on history's recorded values and records the Emerald
+    /// execution block produced for the given Quint proposal.
+    pub async fn decided(
+        &mut self,
+        hist: &mut History,
+        proposal: Proposal,
+        votes: Vec<SignedVote<EmeraldContext>>,
+    ) -> Result<()> {
+        let height = EmeraldHeight::new(proposal.height);
+        let round = EmeraldRound::new(proposal.round);
+        let value_id = hist.get_value_id(&proposal)?;
+        let certificate = CommitCertificate::new(height, round, value_id, votes);
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+        let msg = AppMsg::Decided {
+            extensions: Default::default(),
+            reply: reply_tx,
+            certificate,
+        };
+
+        self.process_msg(msg, reply_rx).await?;
+
+        let state = &self.components.state;
+        let block = state
+            .latest_block
+            .ok_or(anyhow!("Should have filled latest block"))?;
+
+        hist.record_block(proposal, block);
+        Ok(())
+    }
+}
+
+/// Generates mock precommit votes from all nodes for a given proposal.
+pub fn mock_votes(
+    sut: &BTreeMap<Node, Sut>,
+    hist: &History,
+    proposal: &Proposal,
+) -> Result<Vec<SignedVote<EmeraldContext>>> {
+    let mut votes = Vec::new();
+
+    let height = EmeraldHeight::new(proposal.height);
+    let round = EmeraldRound::new(proposal.round);
+    let value_id = hist.get_value_id(proposal)?;
+
+    for (node, app) in sut {
+        let state = &app.components.state;
+        let addr = hist.get_address(node)?;
+        let vote = Vote::new_precommit(height, round, NilOrVal::Val(value_id), addr);
+        let sign = state.signing_provider.sign(&vote.to_sign_bytes());
+        votes.push(SignedVote::new(vote, sign));
+    }
+
+    Ok(votes)
+}

--- a/tests/mbt/src/sut/get_decided.rs
+++ b/tests/mbt/src/sut/get_decided.rs
@@ -1,0 +1,48 @@
+//! Translates GetDecidedValueAction from Quint to AppMsg::GetDecidedValue.
+
+use anyhow::{ensure, Result};
+use malachitebft_app_channel::AppMsg;
+use malachitebft_eth_types::Height as EmeraldHeight;
+
+use super::Sut;
+use crate::history::History;
+use crate::state::{Height, Proposal};
+
+impl Sut {
+    /// Replays the GetDecidedValue Quint action (see emerald.qnt
+    /// handle_get_decided_value).
+    ///
+    /// This method relies on history's recorded proposals to assert that the
+    /// Emerald proposal returned is equal to the expected Quint proposal.
+    pub async fn get_decided(
+        &mut self,
+        hist: &History,
+        height: Height,
+        proposal: Option<Proposal>,
+    ) -> Result<()> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+        let msg = AppMsg::GetDecidedValue {
+            height: EmeraldHeight::new(height),
+            reply: reply_tx,
+        };
+
+        let emerald_proposal = self
+            .process_msg(msg, reply_rx)
+            .await?
+            .map(|decided| {
+                let height = decided.certificate.height;
+                let round = decided.certificate.round;
+                let value_id = decided.certificate.value_id;
+                hist.get_proposal(height, round, value_id)
+            })
+            .transpose()?;
+
+        ensure!(
+            proposal == emerald_proposal,
+            "Spec and emerald decided values diverge: spec={proposal:?} emerald={emerald_proposal:?}"
+        );
+
+        Ok(())
+    }
+}

--- a/tests/mbt/src/sut/get_value.rs
+++ b/tests/mbt/src/sut/get_value.rs
@@ -1,0 +1,53 @@
+//! Translates GetValueAction from Quint to AppMsg::GetValue.
+
+use anyhow::{anyhow, Result};
+use malachitebft_app_channel::app::types::core::Round as EmeraldRound;
+use malachitebft_app_channel::AppMsg;
+use malachitebft_eth_types::Height as EmeraldHeight;
+use tokio::time::Duration;
+
+use super::Sut;
+use crate::history::History;
+use crate::state::{Height, Proposal, Round};
+
+impl Sut {
+    /// Replays the GetValue Quint action (see emerald.qnt handle_get_value).
+    ///
+    /// This method records the Emerald value and message parts for the given
+    /// Quint proposal.
+    pub async fn get_value(
+        &mut self,
+        hist: &mut History,
+        height: Height,
+        round: Round,
+        proposal: Proposal,
+    ) -> Result<()> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+        let msg = AppMsg::GetValue {
+            height: EmeraldHeight::new(height),
+            round: EmeraldRound::new(round),
+            timeout: Duration::ZERO,
+            reply: reply_tx,
+        };
+
+        let emerald_proposal = self.process_msg(msg, reply_rx).await?;
+        let height = emerald_proposal.height;
+        let round = emerald_proposal.round;
+        let value = emerald_proposal.value.clone();
+        let value_id = emerald_proposal.value.id();
+
+        let state = &mut self.components.state;
+        let block_data = state
+            .get_block_data(height, round, value_id)
+            .await
+            .ok_or(anyhow!("No block data for value id: {value_id}"))?;
+
+        let proposal_parts = state
+            .stream_proposal(emerald_proposal, block_data, EmeraldRound::Nil)
+            .collect();
+
+        hist.record_proposal(proposal, value, proposal_parts);
+        Ok(())
+    }
+}

--- a/tests/mbt/src/sut/process_synced_value.rs
+++ b/tests/mbt/src/sut/process_synced_value.rs
@@ -1,0 +1,38 @@
+//! Translates ProcessSyncedValueAction from Quint to AppMsg::ProcessSyncedValue.
+
+use anyhow::Result;
+use malachitebft_app_channel::app::types::codec::Codec;
+use malachitebft_app_channel::app::types::core::Round as EmeraldRound;
+use malachitebft_app_channel::AppMsg;
+use malachitebft_eth_types::codec::proto::ProtobufCodec;
+use malachitebft_eth_types::Height as EmeraldHeight;
+
+use super::Sut;
+use crate::history::History;
+use crate::state::Proposal;
+
+impl Sut {
+    /// Replays the ProcessSyncedValue Quint action (see emerald.qnt
+    /// handle_process_synced_value).
+    ///
+    /// This method relies on history's recorded Emerald value for the given
+    /// Quint proposal.
+    pub async fn process_synced_value(&mut self, hist: &History, proposal: Proposal) -> Result<()> {
+        let proposer = hist.get_address(&proposal.proposer)?;
+        let value = hist.get_value(&proposal.id())?;
+        let value_bytes = ProtobufCodec.encode(&value)?;
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+        let msg = AppMsg::ProcessSyncedValue {
+            height: EmeraldHeight::new(proposal.height),
+            round: EmeraldRound::new(proposal.round),
+            proposer,
+            value_bytes,
+            reply: reply_tx,
+        };
+
+        self.process_msg(msg, reply_rx).await?;
+        Ok(())
+    }
+}

--- a/tests/mbt/src/sut/receive_proposal.rs
+++ b/tests/mbt/src/sut/receive_proposal.rs
@@ -1,0 +1,35 @@
+//! Translates ReceivedProposalAction from Quint to AppMsg::ReceivedProposalPart.
+
+use anyhow::{anyhow, Result};
+use malachitebft_app_channel::AppMsg;
+use malachitebft_core_consensus::PeerId;
+
+use super::Sut;
+use crate::history::History;
+use crate::state::Proposal;
+
+impl Sut {
+    /// Replays the ReceivedProposal Quint action (see emerald.qnt
+    /// handle_received_proposal).
+    ///
+    /// This method relies on history's recorded message parts for the given
+    /// Quint proposal.
+    pub async fn receive_proposal(&mut self, hist: &History, proposal: Proposal) -> Result<()> {
+        let peer_id = PeerId::from_multihash(Default::default())
+            .map_err(|err| anyhow!("Failed to create peer id: {err:?}"))?;
+
+        for part in hist.get_stream(&proposal.id())? {
+            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+            let msg = AppMsg::ReceivedProposalPart {
+                from: peer_id,
+                part: part.clone(),
+                reply: reply_tx,
+            };
+
+            self.process_msg(msg, reply_rx).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/tests/mbt/src/sut/started_round.rs
+++ b/tests/mbt/src/sut/started_round.rs
@@ -1,0 +1,42 @@
+//! Translates StartedRoundAction from Quint to AppMsg::StartedRound.
+
+use anyhow::Result;
+use malachitebft_app_channel::app::types::core::Round as EmeraldRound;
+use malachitebft_app_channel::AppMsg;
+use malachitebft_core_consensus::Role;
+use malachitebft_eth_types::Height as EmeraldHeight;
+
+use super::Sut;
+use crate::history::History;
+use crate::state::{Height, Node, Round};
+
+impl Sut {
+    /// Replays the StartedRound Quint action (see emerald.qnt handle_started_round).
+    pub async fn started_round(
+        &mut self,
+        hist: &History,
+        height: Height,
+        round: Round,
+        proposer: Node,
+    ) -> Result<()> {
+        let proposer = hist.get_address(&proposer)?;
+        let role = if self.address == proposer {
+            Role::Proposer
+        } else {
+            Role::Validator
+        };
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+        let msg = AppMsg::StartedRound {
+            height: EmeraldHeight::new(height),
+            round: EmeraldRound::new(round),
+            reply_value: reply_tx,
+            proposer,
+            role,
+        };
+
+        self.process_msg(msg, reply_rx).await?;
+        Ok(())
+    }
+}

--- a/tests/mbt/tests/mbt.rs
+++ b/tests/mbt/tests/mbt.rs
@@ -1,0 +1,90 @@
+use emerald_mbt::EmeraldDriver;
+use quint_connect::{quint_run, quint_test};
+
+/// Happy path: all 3 nodes start from genesis, the proposer (node1) creates a
+/// proposal, all nodes receive it and decide at height 1.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldSingleHeightConsensusTest",
+    max_samples = 1
+)]
+fn test_single_height_consensus() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Timeout recovery: node1 proposes but all nodes timeout at round 0, advance
+/// to round 1 where node2 proposes, and all nodes successfully decide.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldTimeoutAndDecideTest",
+    max_samples = 1
+)]
+fn test_timeout_and_decide() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Round skipping: nodes 1 and 2 timeout and move ahead, deciding on round 1,
+/// node 3 skips to round 1 and decide.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldSkipsRoundAndDecide",
+    max_samples = 1
+)]
+fn test_skips_round_and_decide() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Sync catch-up: nodes 1 and 2 decide on heights 1 and 2 while node3 is
+/// stalled; node3 catches up by processing synced values for both heights.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldStalledNodeCatchesUpViaSyncTest",
+    max_samples = 1
+)]
+fn test_stalled_node_catches_up_via_sync() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Crash recovery: same as sync catch-up but node3 crashes first, restarts from
+/// genesis (losing all state), then catches up via sync.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldStalledNodeCatchesUpAfterCrashTest",
+    max_samples = 1
+)]
+fn test_stalled_node_catches_up_after_crash() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Restart recovery: node3 syncs and decides height 1, then does a process
+/// restart (preserving decided state), and catches up on height 2 via sync.
+#[quint_test(
+    spec = "../../specs/emerald_tests.qnt",
+    test = "emeraldStalledNodeCatchesUpAfterRestartTest",
+    max_samples = 1
+)]
+fn test_stalled_node_catches_up_after_restart() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Random exploration without any failures.
+#[quint_run(
+    spec = "../../specs/emerald_mbt.qnt",
+    step = "step_no_failures",
+    max_samples = 32,
+    max_steps = 128
+)]
+fn simulation_no_failures() -> impl Driver {
+    EmeraldDriver::default()
+}
+
+/// Random exploration allowing at most one failure per (node, height) pair.
+#[quint_run(
+    spec = "../../specs/emerald_mbt.qnt",
+    step = "step_with_failures",
+    max_samples = 32,
+    max_steps = 128
+)]
+fn simulation_with_failures() -> impl Driver {
+    EmeraldDriver::default()
+}


### PR DESCRIPTION
This patch connects the newly added Quint specs to Emerald's code via the Quint Connect library.

PS: the best files to start reviewing are probable `tests.rs` and `driver.rs`.