### PR TITLE
test(mbt): Model value sync for Emerald specs

### DIFF
--- a/specs/emerald.qnt
+++ b/specs/emerald.qnt
@@ -220,7 +220,13 @@ module emerald {
 
     if (s.phase == Working)
       ctx.extensions.all_proposals.filterMap(p => {
-        if (p.height >= s.consensus_height and not(p.in(s.proposals)))
+        if (and {
+          // Note that a node does not receive a proposal of its own. Recovering
+          // its proposals after a crash is done via the sync protocol instead.
+          p.proposer != s.process_id,
+          p.height >= s.consensus_height,
+          not(p.in(s.proposals))
+        })
           Some(p)
         else
           None
@@ -257,7 +263,7 @@ module emerald {
   pure def listen_decided(ctx: LocalContext): Set[Proposal] = {
     val s = ctx.state
 
-    if (s.phase == Working)
+    if (s.phase == Working or s.phase == Syncing)
       match get_global_decision(ctx, s.consensus_height) {
         // There isn't a decision for the consensus height. Let's mimic
         // Malachite consensus and have some node decide on a proposal for the
@@ -321,7 +327,7 @@ module emerald {
   pure def listen_process_synced_value(ctx: LocalContext): Set[Proposal] = {
     val s = ctx.state
 
-    if (s.phase == Working)
+    if (s.phase == Working or s.phase == Syncing)
       val decided_proposal_for_height =
         ctx.extensions.decided_proposals
           .find(p => and {
@@ -343,6 +349,7 @@ module emerald {
     {
       post_state: {
         ...s,
+        phase: Syncing,
         proposals: s.proposals.setAdd(proposal)
       },
       effects: Set(

--- a/specs/emerald_types.qnt
+++ b/specs/emerald_types.qnt
@@ -33,10 +33,16 @@ module emerald_types {
   // During normal operation, Emerald moves back to "Ready" at the end of each
   // consensus height (Decided), then back to "Working" once the new height
   // starts (StartedRound).
+  //
+  // The "Syncing" mode models the state after Malachite's sync protocol
+  // triggers the ProcessSyncedValue message, which Malachite is expected to
+  // immediately follow with a Decided message confirming the newly received
+  // proposal.
   type AppPhase =
     | Uninitialized // Before ConsensusReady
     | Ready         // After ConsensusReady or Decided, before StartedRound
     | Working       // After StartedRound
+    | Syncing       // After ProcessSyncedValue
 
   // A consensus proposal
   type Proposal = {


### PR DESCRIPTION
Originally, we didn't model a syncing phase for the Emerald spec believing that, from the perspective of the model, syncing would be just another form of learning about proposals. However, we got a failure that showed us an unexpected interleaving after a server crash:

```
  run repro =
    genesisStart
      // Node 1 proposes, nodes 2 and 3 decide
      .then("node1".getValue(proposal(1, 0, 0)))
      .then("node2".receivedProposal(proposal(1, 0, 0)))
      .then("node3".receivedProposal(proposal(1, 0, 0)))
      .then("node2".decided(proposal(1, 0, 0)))
      .then("node3".decided(proposal(1, 0, 0)))
      // Node 1 crashes and restarts
      .then("node1".crash())
      .then("node1".consensusReady(1, 0))
      .then("node1".startedRound(1, 0))
      // Node 1 proposes a new value
      .then("node1".getValue(proposal(1, 0, 1)))
      // Node 1 receives the decided value for height=1
      .then("node1".processSyncedValue(proposal(1, 0, 0)))
      // Node 1 now has 2 proposals for height=1 and round=0
      .expect(
        val proposals = s.system.get("node1").proposals
        and {
          proposal(1, 0, 0).in(proposals),
          proposal(1, 0, 1).in(proposals)
        }
      )
      // THIS SHOULD NOT BE ALLOWED!
      //
      // After receiving a value via sync,
      // Malachite will immediately call Decided.
      .then("node1".getValue(proposal(1, 0, 0)))
```

This patch introduces a new phase called Syncing that is enabled **after** receiving a ProcessSyncedValue message. In this phase, correct process should only commit the newly received proposal, thus adhering to the Malachite semantics when value sync is triggered.