### PR TITLE
test(mbt): Only sync and decide on current round

### DIFF
--- a/specs/emerald.qnt
+++ b/specs/emerald.qnt
@@ -277,8 +277,9 @@ module emerald {
         // the decision as long as the Emerald node is at the same height.
         | Some(p) =>
             if (and {
-              p.in(s.proposals),
-              p.height == s.consensus_height
+              p.height == s.consensus_height,
+              p.round == s.consensus_round,
+              p.in(s.proposals)
             })
               Set(p)
             else
@@ -332,6 +333,7 @@ module emerald {
         ctx.extensions.decided_proposals
           .find(p => and {
             p.height == s.consensus_height,
+            p.round == s.consensus_round,
             not(p.in(s.proposals))
           })
 


### PR DESCRIPTION
Previously we presumed that `ProcessSyncedValue` and `Decided` could be called for any round in the current height. However, after close inspection of the Malachite codebase, it seems that it's safe to assume that sync and decided messages are only ever called for the current height and round pair.

This came up in CI where seed `QUINT_SEED=0x756972d8` produced a trace where Emerald could not decide on a block because it was from a higher round:

```
// =============================================================================
// MBT FAILURE REPRODUCTION TEST
// =============================================================================
// Reproduces trace from: QUINT_SEED=0x756972d8 simulation_with_failures
// Error: "certificate should have associated block data"
//
// This trace demonstrates a scenario where node1 decides on a proposal
// (height 2, round 1) from node3, but doesn't have the associated block data
// because node3 crashed after proposing but before node1 received the block.
run emeraldMbtFailureReproductionTest =
  init
    // node1 and node3 become ready and start round at height 1
    .then("node1".consensusReady(1, 0))
    .then("node3".consensusReady(1, 0))
    .then("node1".startedRound(1, 0))
    .then("node3".startedRound(1, 0))
    // node1 proposes and both nodes decide on height 1
    .then("node1".getValue(proposal(1, 0, 0)))
    .then("node3".receivedProposal(proposal(1, 0, 0)))
    .then("node1".decided(proposal(1, 0, 0)))
    .then("node3".decided(proposal(1, 0, 0)))
    // node1 crashes and recovers at height 1
    .then("node1".crash())
    .then("node1".consensusReady(1, 0))
    .then("node1".startedRound(1, 0))
    // node3 progresses to height 2, times out to round 1 (where node3 is proposer)
    .then("node3".startedRound(2, 0))
    .then("node3".timeout(2, 0))
    .then("node3".startedRound(2, 1))
    // node3 proposes at height 2, round 1
    .then("node3".getValue(proposal(2, 1, 1)))
    // node1 receives future proposal, syncs height 1, decides height 1
    .then("node1".receivedProposal(proposal(2, 1, 1)))
    .then("node1".processSyncedValue(proposal(1, 0, 0)))
    .then("node1".decided(proposal(1, 0, 0)))
    // node3 decides on height 2
    .then("node3".decided(proposal(2, 1, 1)))
    // node1 starts round at height 2
    .then("node1".startedRound(2, 0))
    // node1 tries to decide on height 2 - FAILS: no block data available
    .then("node1".decided(proposal(2, 1, 1)))
    .expect(
      val st = s.system.get("node1")
      and {
        st.last_decided_height == 2,
        st.last_decided_payload == Some(1)
      }
    )
```

The Quint run above triggers a panic at app/src/app.rs#L659.

This patch changes the spec so that we don't emit a `Decided` or `ProcessSyncedValue` messages unless the application is at the same height and round of as the decided value. With this change, the Quint run above has to be adjusted to timeout and move the next round before deciding:

```
  // node1 tries to decide on height 2
  .then("node1".timeout(2, 0))
  .then("node1".startedRound(2, 1))
  .then("node1".decided(proposal(2, 1, 1)))
```