### PR TITLE
feat(app): use jemalloc as global allocator on non-MSVC targets

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -48,5 +48,10 @@ tracing         = { workspace = true }
 url             = { workspace = true }
 humantime-serde = { workspace = true }
 
+# jemalloc reclaims freed memory to the OS more aggressively than glibc malloc,
+# keeping RSS lower for the long-running node. Not available on MSVC targets.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dev-dependencies]
 tempfile = "3"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,3 +1,10 @@
+// Use jemalloc as the global allocator on non-MSVC targets. glibc's default
+// malloc is not aggressive about returning freed memory to the OS, which keeps
+// RSS elevated for long-running nodes; jemalloc reclaims more eagerly.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use color_eyre::eyre::{eyre, Result};
 use emerald::node::App;
 use malachitebft_app_channel::app::node::Node;


### PR DESCRIPTION
glibc malloc is not aggressive about returning freed memory to the OS, keeping RSS elevated for the long-running node. Set tikv-jemallocator as the global allocator (gated on not(target_env = "msvc")) to reclaim memory more eagerly, mirroring the l1client node binary.